### PR TITLE
Updated trigger overlay structs so that fields have nice alignment in memory

### DIFF
--- a/include/detdataformats/trigger/TriggerActivityData.hpp
+++ b/include/detdataformats/trigger/TriggerActivityData.hpp
@@ -16,7 +16,6 @@ namespace dunedaq {
 namespace detdataformats {
 namespace trigger {
 
-#pragma pack(1)
 struct TriggerActivityData
 {
   enum class Type : uint32_t // NOLINT(build/unsigned)
@@ -53,7 +52,6 @@ struct TriggerActivityData
   uint16_t unused1 = 0x1e1e;                 // NOLINT(build/unsigned)
   uint32_t unused2 = 0x2d2d3c3c;             // NOLINT(build/unsigned)
 };
-#pragma pack(0)
 static_assert(sizeof(TriggerActivityData) == 72, "TriggerActivityData size different than expected!");
 
 } // namespace trigger

--- a/include/detdataformats/trigger/TriggerActivityData.hpp
+++ b/include/detdataformats/trigger/TriggerActivityData.hpp
@@ -16,16 +16,17 @@ namespace dunedaq {
 namespace detdataformats {
 namespace trigger {
 
+#pragma pack(1)
 struct TriggerActivityData
 {
-  enum class Type
+  enum class Type : uint32_t // NOLINT(build/unsigned)
   {
     kUnknown = 0,
     kTPC = 1,
     kPDS = 2,
   };
 
-  enum class Algorithm
+  enum class Algorithm : uint32_t // NOLINT(build/unsigned)
   {
     kUnknown = 0,
     kSupernova = 1,
@@ -35,21 +36,25 @@ struct TriggerActivityData
 
   // Update this version number if there are any changes to the in-memory representation of this class!
   static constexpr version_t s_trigger_activity_version = 1; // NOLINT(build/unsigned)
-  
+
   version_t version = s_trigger_activity_version; // NOLINT(build/unsigned)
+  detid_t detid = INVALID_DETID;                  // NOLINT(build/unsigned)
+  channel_t channel_start = INVALID_CHANNEL;      // NOLINT(build/unsigned)
+  channel_t channel_end = INVALID_CHANNEL;        // NOLINT(build/unsigned)
+  channel_t channel_peak = INVALID_CHANNEL;       // NOLINT(build/unsigned)
   timestamp_t time_start = INVALID_TIMESTAMP;
   timestamp_t time_end = INVALID_TIMESTAMP;
   timestamp_t time_peak = INVALID_TIMESTAMP;
   timestamp_t time_activity = INVALID_TIMESTAMP;
-  channel_t channel_start = INVALID_CHANNEL; // NOLINT(build/unsigned)
-  channel_t channel_end = INVALID_CHANNEL;   // NOLINT(build/unsigned)
-  channel_t channel_peak = INVALID_CHANNEL;  // NOLINT(build/unsigned)
-  uint64_t adc_integral = 0;                 // NOLINT(build/unsigned)
-  uint16_t adc_peak = 0;                     // NOLINT(build/unsigned)
-  detid_t detid = INVALID_DETID;             // NOLINT(build/unsigned)
   Type type = Type::kUnknown;                // NOLINT(build/unsigned)
   Algorithm algorithm = Algorithm::kUnknown; // NOLINT(build/unsigned)
+  uint64_t adc_integral = 0;                 // NOLINT(build/unsigned)
+  uint16_t adc_peak = 0;                     // NOLINT(build/unsigned)
+  uint16_t unused1 = 0x1e1e;                 // NOLINT(build/unsigned)
+  uint32_t unused2 = 0x2d2d3c3c;             // NOLINT(build/unsigned)
 };
+#pragma pack(0)
+static_assert(sizeof(TriggerActivityData) == 72, "TriggerActivityData size different than expected!");
 
 } // namespace trigger
 } // namespace detdataformats

--- a/include/detdataformats/trigger/TriggerCandidateData.hpp
+++ b/include/detdataformats/trigger/TriggerCandidateData.hpp
@@ -17,9 +17,10 @@ namespace dunedaq {
 namespace detdataformats {
 namespace trigger {
 
+#pragma pack(1)
 struct TriggerCandidateData
 {
-  enum class Type
+  enum class Type : uint32_t // NOLINT(build/unsigned)
   {
     kUnknown = 0,
     kTiming = 1,
@@ -30,7 +31,7 @@ struct TriggerCandidateData
     kADCSimpleWindow = 6,
   };
 
-  enum class Algorithm
+  enum class Algorithm : uint32_t // NOLINT(build/unsigned)
   {
     kUnknown = 0,
     kSupernova = 1,
@@ -42,18 +43,21 @@ struct TriggerCandidateData
   // Update this version number if there are any changes to the in-memory representation of this class!
   static constexpr version_t s_trigger_candidate_version = 1; // NOLINT(build/unsigned)
 
-  version_t version = s_trigger_candidate_version;       // NOLINT(build/unsigned)
-  timestamp_t time_start = INVALID_TIMESTAMP;
-  timestamp_t time_end = INVALID_TIMESTAMP;
-  timestamp_t time_candidate = INVALID_TIMESTAMP;
+  version_t version = s_trigger_candidate_version; // NOLINT(build/unsigned)
   // TODO P. Rodrigues 2021-01-06: This was originally a
   // std::vector<detid_t> but that messes up the overlay scheme, so
   // I've changed it for now to be just a detid_t. Need to work out
   // what to do longer term
   detid_t detid; // NOLINT(build/unsigned)
   Type type = Type::kUnknown;
+  timestamp_t time_start = INVALID_TIMESTAMP;
+  timestamp_t time_end = INVALID_TIMESTAMP;
+  timestamp_t time_candidate = INVALID_TIMESTAMP;
   Algorithm algorithm = Algorithm::kUnknown; // NOLINT(build/unsigned)
+  uint32_t unused = 0x4b4b5a5a;              // NOLINT(build/unsigned)
 };
+#pragma pack(0)
+static_assert(sizeof(TriggerCandidateData) == 40, "TriggerCandidateData size different than expected!");
 
 } // namespace trigger
 } // namespace detdataformats

--- a/include/detdataformats/trigger/TriggerCandidateData.hpp
+++ b/include/detdataformats/trigger/TriggerCandidateData.hpp
@@ -17,7 +17,6 @@ namespace dunedaq {
 namespace detdataformats {
 namespace trigger {
 
-#pragma pack(1)
 struct TriggerCandidateData
 {
   enum class Type : uint32_t // NOLINT(build/unsigned)
@@ -56,7 +55,6 @@ struct TriggerCandidateData
   Algorithm algorithm = Algorithm::kUnknown; // NOLINT(build/unsigned)
   uint32_t unused = 0x4b4b5a5a;              // NOLINT(build/unsigned)
 };
-#pragma pack(0)
 static_assert(sizeof(TriggerCandidateData) == 40, "TriggerCandidateData size different than expected!");
 
 } // namespace trigger

--- a/include/detdataformats/trigger/TriggerPrimitive.hpp
+++ b/include/detdataformats/trigger/TriggerPrimitive.hpp
@@ -24,7 +24,6 @@ namespace trigger {
 /**
  * @brief A single energy deposition on a TPC or PDS channel
  */
-#pragma pack(1)
 struct TriggerPrimitive
 {
   /**
@@ -68,7 +67,6 @@ struct TriggerPrimitive
   Type type = Type::kUnknown;
   Algorithm algorithm = Algorithm::kUnknown;
 };
-#pragma pack(0)
 static_assert(sizeof(TriggerPrimitive) == 48, "TriggerPrimitive size different than expected!");
 
 /**

--- a/include/detdataformats/trigger/TriggerPrimitive.hpp
+++ b/include/detdataformats/trigger/TriggerPrimitive.hpp
@@ -24,12 +24,13 @@ namespace trigger {
 /**
  * @brief A single energy deposition on a TPC or PDS channel
  */
+#pragma pack(1)
 struct TriggerPrimitive
 {
   /**
    * @brief The type of a TriggerPrimitive
    */
-  enum class Type
+  enum class Type : uint32_t // NOLINT(build/unsigned)
   {
     kUnknown = 0,
     kTPC = 1,
@@ -39,7 +40,7 @@ struct TriggerPrimitive
   /**
    * @brief The algorithm used to form a TriggerPrimitive
    */
-  enum class Algorithm
+  enum class Algorithm : uint32_t // NOLINT(build/unsigned)
   {
     kUnknown = 0,
     kTPCDefault = 1
@@ -54,20 +55,21 @@ struct TriggerPrimitive
 
   // Update this version number if there are any changes to the in-memory representation of this class!
   static constexpr version_t s_trigger_primitive_version = 1; // NOLINT(build/unsigned)
-  
+
   version_t version = s_trigger_primitive_version; // NOLINT(build/unsigned)
+  Flags flag = 0;
+  channel_t channel = INVALID_CHANNEL;
   timestamp_t time_start = INVALID_TIMESTAMP;
   timestamp_t time_peak = INVALID_TIMESTAMP;
   timestamp_t time_over_threshold = INVALID_TIMESTAMP;
-  channel_t channel = INVALID_CHANNEL;
   uint32_t adc_integral = { 0 }; // NOLINT(build/unsigned)
   uint16_t adc_peak = { 0 };     // NOLINT(build/unsigned)
   detid_t detid = INVALID_DETID;
   Type type = Type::kUnknown;
   Algorithm algorithm = Algorithm::kUnknown;
-
-  Flags flag = 0;
 };
+#pragma pack(0)
+static_assert(sizeof(TriggerPrimitive) == 48, "TriggerPrimitive size different than expected!");
 
 /**
  * Names for each of the bits in the TriggerPrimitive Flags


### PR DESCRIPTION
These changes are based on conversations that we've had in the last day about byte alignment.  
As I moved fields around in structs, I simply considered their size in memory, and there may certainly be better orderings that are possible.

The principles that I used in these changes were:

1. always have 32-bit and 64-bit fields aligned to the appropriate byte boundaries to help ensure good performance
2. explicitly added padding at the end of the struct, if needed to ensure an integer number of 64-bit words in the struct
3. explicitly requested struct "packing" to keep the compiler from silently adding padding
4. using a static_assert to ensure that the size of the struct is what we expected
5. explicitly specifying the size of enum types

Items 2-5 help us ensure that we know exactly what will appear in memory for each struct.

These changes were informed by Eric's proposed notes on struct padding ([here](https://github.com/DUNE-DAQ/daqdataformats/blob/kbiery/df_tp_stream/docs/DataFormatNotes.md#padding-and-alignment-in-struct-definitions)).