### PR TITLE
Add kHorizontalMuon type/algorithm for TA/TC (v2.10.2)

### DIFF
--- a/include/detdataformats/trigger/TriggerActivityData.hpp
+++ b/include/detdataformats/trigger/TriggerActivityData.hpp
@@ -30,7 +30,8 @@ struct TriggerActivityData
     kUnknown = 0,
     kSupernova = 1,
     kPrescale = 2,
-    kADCSimpleWindow = 3
+    kADCSimpleWindow = 3,
+    kHorizontalMuon = 4,
   };
 
   // Update this version number if there are any changes to the in-memory representation of this class!

--- a/include/detdataformats/trigger/TriggerCandidateData.hpp
+++ b/include/detdataformats/trigger/TriggerCandidateData.hpp
@@ -28,6 +28,7 @@ struct TriggerCandidateData
     kRandom = 4,
     kPrescale = 5,
     kADCSimpleWindow = 6,
+    kHorizontalMuon = 7,
   };
 
   enum class Algorithm
@@ -36,7 +37,8 @@ struct TriggerCandidateData
     kSupernova = 1,
     kHSIEventToTriggerCandidate = 2,
     kPrescale = 3,
-    kADCSimpleWindow = 4
+    kADCSimpleWindow = 4,
+    kHorizontalMuon = 5,
   };
 
   // Update this version number if there are any changes to the in-memory representation of this class!


### PR DESCRIPTION
This PR adds a kHorizontalMuon enumeration for the new horizontal muon TA and TC algorithms, which are in triggeralgs. This PR is to merge into v2.10.2, so it replaces #17, which was to merge into develop (that will be done later)