### PR TITLE
Wketchum/fixes for v2.11.1

### DIFF
--- a/include/detdataformats/wib2/WIB2Frame.hpp
+++ b/include/detdataformats/wib2/WIB2Frame.hpp
@@ -51,7 +51,7 @@ public:
 
   struct Header
   {
-    word_t version : 6, detector_id : 6, crate : 10, slot : 4, link : 6;
+    word_t version : 6, detector_id : 6, crate : 10, slot : 3, unused : 1, link : 6;
     word_t timestamp_1 : 32;
     word_t timestamp_2 : 32;
     word_t tbd_1 : 13, colddata_timestamp_id : 3, femb_valid : 2, link_mask : 8, lock_output_status : 1, tbd_2 : 5;

--- a/pybindsrc/wib2.cpp
+++ b/pybindsrc/wib2.cpp
@@ -33,8 +33,8 @@ register_wib2(py::module& m)
     .def("get_v", static_cast<uint16_t (WIB2Frame::*)(const int, const int) const>(&WIB2Frame::get_v))
     .def("get_x", static_cast<uint16_t (WIB2Frame::*)(const int, const int) const>(&WIB2Frame::get_x))
     .def("get_timestamp", &WIB2Frame::get_timestamp)
-    .def_property_readonly("header", [](WIB2Frame& self) -> const WIB2Frame::Header& {return self.header;})
-    .def_property_readonly("trailer", [](WIB2Frame& self) -> const WIB2Frame::Trailer& {return self.trailer;})
+    .def("get_header", [](WIB2Frame& self) -> const WIB2Frame::Header& {return self.header;})
+    .def("get_trailer", [](WIB2Frame& self) -> const WIB2Frame::Trailer& {return self.trailer;})
     .def_static("sizeof", [](){ return sizeof(WIB2Frame); })
   ;
 

--- a/pybindsrc/wib2.cpp
+++ b/pybindsrc/wib2.cpp
@@ -33,6 +33,8 @@ register_wib2(py::module& m)
     .def("get_v", static_cast<uint16_t (WIB2Frame::*)(const int, const int) const>(&WIB2Frame::get_v))
     .def("get_x", static_cast<uint16_t (WIB2Frame::*)(const int, const int) const>(&WIB2Frame::get_x))
     .def("get_timestamp", &WIB2Frame::get_timestamp)
+    .def_property_readonly("header", [](WIB2Frame& self) -> const WIB2Frame::Header& {return self.header;})
+    .def_property_readonly("trailer", [](WIB2Frame& self) -> const WIB2Frame::Trailer& {return self.trailer;})
     .def_static("sizeof", [](){ return sizeof(WIB2Frame); })
   ;
 

--- a/python/detdataformats/daphne/__init__.py
+++ b/python/detdataformats/daphne/__init__.py
@@ -1,0 +1,1 @@
+from .._daq_detdataformats_py.wib import *

--- a/python/detdataformats/daphne/__init__.py
+++ b/python/detdataformats/daphne/__init__.py
@@ -1,1 +1,1 @@
-from .._daq_detdataformats_py.wib import *
+from .._daq_detdataformats_py.daphne import *

--- a/python/detdataformats/wib2/__init__.py
+++ b/python/detdataformats/wib2/__init__.py
@@ -1,0 +1,1 @@
+from .._daq_detdataformats_py.daphne import *

--- a/python/detdataformats/wib2/__init__.py
+++ b/python/detdataformats/wib2/__init__.py
@@ -1,1 +1,1 @@
-from .._daq_detdataformats_py.daphne import *
+from .._daq_detdataformats_py.wib2 import *


### PR DESCRIPTION
Pulls commits from `thea/wib2_daphne_bindings` and also an update to the wib2 frame header first word to account for an unused bit in the slot.

branch based off of v2.11.0, and should be merged to a 2.11.1 patch release and then also to develop.