### PR TITLE
Fix the WIB2Frame setter

### DIFF
--- a/include/detdataformats/wib2/WIB2Frame.hpp
+++ b/include/detdataformats/wib2/WIB2Frame.hpp
@@ -125,11 +125,13 @@ public:
     int first_bit_position = (s_bits_per_adc * i) % s_bits_per_word;
     // How many bits of our desired ADC are located in the `word_index`th word
     int bits_in_first_word = std::min(s_bits_per_adc, s_bits_per_word - first_bit_position);
-    adc_words[word_index] |= (val << first_bit_position);
+    uint32_t mask = (1 << (first_bit_position)) - 1;
+    adc_words[word_index] = ((val << first_bit_position) & ~mask) | (adc_words[word_index] & mask);
     // If we didn't put the full 14 bits in this word, we need to put the rest in the next word
     if (bits_in_first_word < s_bits_per_adc) {
       assert(word_index + 1 < s_num_adc_words);
-      adc_words[word_index + 1] |= val >> bits_in_first_word;
+      mask = (1 << (s_bits_per_adc - bits_in_first_word)) - 1;
+      adc_words[word_index + 1] = ((val >> bits_in_first_word) & mask) | (adc_words[word_index + 1] & ~mask);
     }
   }
 


### PR DESCRIPTION
The issue was that the operator `|=` was being used to set the bits in the words. With this operator, bits in the current word (remember that each ADC is 14 bits so there are several ADCs in the same word) that are set to 1 will still be set to 1 even if the current value of the bit of the ADC that we are setting is set to 0.

The new approach is to make a mask of the bits we want to change (and it's complementary is the bits that we don't want to change) and do the assignment 

``` c++
word = (word & ~mask) | (adc_value & mask)
```