### PR TITLE
Add python bindings for setters and serialization

### DIFF
--- a/pybindsrc/wib.cpp
+++ b/pybindsrc/wib.cpp
@@ -34,8 +34,17 @@ register_wib(py::module& m)
     .def("get_channel", static_cast<uint16_t (WIBFrame::*)(const uint8_t, const uint8_t, const uint8_t) const>(&WIBFrame::get_channel))
     .def("get_channel", static_cast<uint16_t (WIBFrame::*)(const uint8_t, const uint8_t) const>(&WIBFrame::get_channel))
     .def("get_channel", static_cast<uint16_t (WIBFrame::*)(const uint8_t) const>(&WIBFrame::get_channel))
+    .def("set_channel", static_cast<void (WIBFrame::*)(const uint8_t, const uint16_t)>(&WIBFrame::set_channel))
     .def("get_timestamp", &WIBFrame::get_timestamp)
     .def_static("sizeof", [](){ return sizeof(WIBFrame); })
+    .def("get_bytes",
+         [](WIBFrame* fr) -> py::bytes {
+          std::vector<char> v;
+          auto p = reinterpret_cast<char*>(fr);
+          for (size_t i = 0; i < sizeof(WIBFrame); i++, p++) v.push_back(*p);
+          return py::bytes(v.data(), sizeof(WIBFrame));
+        }
+    )
   ;
 
   py::class_<WIBHeader>(m, "WIBHeader")

--- a/pybindsrc/wib.cpp
+++ b/pybindsrc/wib.cpp
@@ -39,10 +39,7 @@ register_wib(py::module& m)
     .def_static("sizeof", [](){ return sizeof(WIBFrame); })
     .def("get_bytes",
          [](WIBFrame* fr) -> py::bytes {
-          std::vector<char> v;
-          auto p = reinterpret_cast<char*>(fr);
-          for (size_t i = 0; i < sizeof(WIBFrame); i++, p++) v.push_back(*p);
-          return py::bytes(v.data(), sizeof(WIBFrame));
+           return py::bytes(reinterpret_cast<char*>(fr), sizeof(WIBFrame));
         }
     )
   ;

--- a/pybindsrc/wib2.cpp
+++ b/pybindsrc/wib2.cpp
@@ -29,10 +29,19 @@ register_wib2(py::module& m)
         return wfp;
     } ))
     .def("get_adc", static_cast<uint16_t (WIB2Frame::*)(const int) const>(&WIB2Frame::get_adc))
+    .def("set_adc", static_cast<void (WIB2Frame::*)(int, uint16_t)>(&WIB2Frame::set_adc))
     .def("get_timestamp", &WIB2Frame::get_timestamp)
     .def("get_header", [](WIB2Frame& self) -> const WIB2Frame::Header& {return self.header;})
     .def("get_trailer", [](WIB2Frame& self) -> const WIB2Frame::Trailer& {return self.trailer;})
     .def_static("sizeof", [](){ return sizeof(WIB2Frame); })
+    .def("get_bytes",
+         [](WIB2Frame* fr) -> py::bytes {
+          std::vector<char> v;
+          auto p = reinterpret_cast<char*>(fr);
+          for (size_t i = 0; i < sizeof(WIB2Frame); i++, p++) v.push_back(*p);
+          return py::bytes(v.data(), sizeof(WIB2Frame));
+        }
+    )
   ;
 
   py::class_<WIB2Frame::Header>(m, "WIB2Header")

--- a/pybindsrc/wib2.cpp
+++ b/pybindsrc/wib2.cpp
@@ -36,10 +36,7 @@ register_wib2(py::module& m)
     .def_static("sizeof", [](){ return sizeof(WIB2Frame); })
     .def("get_bytes",
          [](WIB2Frame* fr) -> py::bytes {
-          std::vector<char> v;
-          auto p = reinterpret_cast<char*>(fr);
-          for (size_t i = 0; i < sizeof(WIB2Frame); i++, p++) v.push_back(*p);
-          return py::bytes(v.data(), sizeof(WIB2Frame));
+           return py::bytes(reinterpret_cast<char*>(fr), sizeof(WIB2Frame));
         }
     )
   ;


### PR DESCRIPTION
which allows to create frames and modify frames from python and to save them to binary files (i.e. you can make a `frames.bin` file with whichever pattern you want directly from python):

``` python
with open('frames.bin', 'wb') as f:
    fr = WIBFrame()
    # Modify using the setter if needed
    ...
    #
    f.write(fr.get_bytes())
```