### PR TITLE
Fix compiler warnings

### DIFF
--- a/include/detdataformats/daphne/DAPHNEFrame.hpp
+++ b/include/detdataformats/daphne/DAPHNEFrame.hpp
@@ -19,7 +19,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <stdexcept> // For std::out_of_range
-#include <stdint.h>  // For uint32_t etc
+#include <cstdint>  // For uint32_t etc
 
 namespace dunedaq {
 namespace detdataformats {

--- a/include/detdataformats/daphne/DAPHNEFrame.hpp
+++ b/include/detdataformats/daphne/DAPHNEFrame.hpp
@@ -125,7 +125,7 @@ public:
     // If we didn't put the full 14 bits in this word, we need to put the rest in the next word
     if (bits_in_first_word < s_bits_per_adc) {
       assert(word_index + 1 < s_num_adc_words);
-            mask = (1 << (s_bits_per_adc - bits_in_first_word)) - 1;
+      mask = (1 << (s_bits_per_adc - bits_in_first_word)) - 1;
       adc_words[word_index + 1] = ((val >> bits_in_first_word) & mask) | (adc_words[word_index + 1] & ~mask);
     }
   }

--- a/include/detdataformats/daphne/DAPHNEFrame.hpp
+++ b/include/detdataformats/daphne/DAPHNEFrame.hpp
@@ -120,11 +120,13 @@ public:
     int first_bit_position = (s_bits_per_adc * i) % s_bits_per_word;
     // How many bits of our desired ADC are located in the `word_index`th word
     int bits_in_first_word = std::min(s_bits_per_adc, s_bits_per_word - first_bit_position);
-    adc_words[word_index] |= (val << first_bit_position);
+    uint32_t mask = (1 << (first_bit_position)) - 1;
+    adc_words[word_index] = ((val << first_bit_position) & ~mask) | (adc_words[word_index] & mask);
     // If we didn't put the full 14 bits in this word, we need to put the rest in the next word
     if (bits_in_first_word < s_bits_per_adc) {
       assert(word_index + 1 < s_num_adc_words);
-      adc_words[word_index + 1] |= val >> bits_in_first_word;
+            mask = (1 << (s_bits_per_adc - bits_in_first_word)) - 1;
+      adc_words[word_index + 1] = ((val >> bits_in_first_word) & mask) | (adc_words[word_index + 1] & ~mask);
     }
   }
 

--- a/include/detdataformats/hsi/TimingHSIFrame.hpp
+++ b/include/detdataformats/hsi/TimingHSIFrame.hpp
@@ -11,7 +11,7 @@
 #ifndef DETDATAFORMATS_INCLUDE_HSI_TIMINGHSIFRAME_HPP_
 #define DETDATAFORMATS_INCLUDE_HSI_TIMINGHSIFRAME_HPP_
 
-#include <stdint.h>  // For uint32_t etc
+#include <cstdint>  // For uint32_t etc
 
 namespace dunedaq {
 namespace detdataformats {

--- a/include/detdataformats/pacman/PACMANFrame.hpp
+++ b/include/detdataformats/pacman/PACMANFrame.hpp
@@ -10,7 +10,7 @@
 
 #include <bitset>
 #include <iostream>
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 
 namespace dunedaq {

--- a/unittest/WIB2Frame_test.cxx
+++ b/unittest/WIB2Frame_test.cxx
@@ -1,5 +1,5 @@
 /**
- * @file WIBFrame_test.cxx WIBFrame class Unit Tests
+ * @file WIB2Frame_test.cxx WIB2Frame class Unit Tests
  *
  * This is part of the DUNE DAQ Application Framework, copyright 2020.
  * Licensing/copyright details are in the COPYING file that you should have
@@ -40,7 +40,7 @@ typedef struct
   uint32_t femb_b_seg[56]; // NOLINT(build/unsigned)
   uint32_t wib_post[2];    // NOLINT(build/unsigned)
   uint32_t idle_frame;     // NOLINT(build/unsigned)
-} __attribute__((packed)) frame14;
+} frame14;
 
 // Samples from the U, V, X channels in a femb_*_seg of a frame as 16bit arrays
 typedef struct

--- a/unittest/WIBFrame_test.cxx
+++ b/unittest/WIBFrame_test.cxx
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE(WIBHeader_TimestampMethods)
 }
 BOOST_AUTO_TEST_CASE(WIBHeader_StreamMethods)
 {
-  WIBHeader header;
+  WIBHeader header {};
 
   std::ostringstream ostr;
   header.print_hex(ostr);
@@ -189,7 +189,7 @@ BOOST_AUTO_TEST_CASE(ColdataHeader_HdrMethods)
 }
 BOOST_AUTO_TEST_CASE(ColdataHeader_StreamMethods)
 {
-  ColdataHeader header;
+  ColdataHeader header {};
 
   std::ostringstream ostr;
   header.print_hex(ostr);
@@ -216,7 +216,7 @@ BOOST_AUTO_TEST_CASE(ColdataHeader_StreamMethods)
 
 BOOST_AUTO_TEST_CASE(ColdataSegment_ChannelMethods)
 {
-  ColdataSegment segment;
+  ColdataSegment segment {};
   segment.adc0ch0_1 = 0x11;
   segment.adc1ch0_1 = 0x22;
   segment.adc0ch0_2 = 0x3;
@@ -369,7 +369,7 @@ BOOST_AUTO_TEST_CASE(ColdataBlock_ChannelMethods)
 }
 BOOST_AUTO_TEST_CASE(ColdataBlock_StreamOperator)
 {
-  ColdataBlock block;
+  ColdataBlock block {};
 
   std::ostringstream ostr;
   ostr << block;
@@ -380,7 +380,7 @@ BOOST_AUTO_TEST_CASE(ColdataBlock_StreamOperator)
 
 BOOST_AUTO_TEST_CASE(WIBFrame_StructMethods)
 {
-  WIBFrame frame;
+  WIBFrame frame {};
 
   BOOST_REQUIRE(frame.get_wib_header() != nullptr);
   BOOST_REQUIRE(frame.get_coldata_header(0) != nullptr);
@@ -461,7 +461,7 @@ BOOST_AUTO_TEST_CASE(WIBFrame_BlockChannelMethods)
 }
 BOOST_AUTO_TEST_CASE(WIBFrame_StreamOperator)
 {
-  WIBFrame frame;
+  WIBFrame frame {};
 
   std::ostringstream ostr;
   ostr << frame;


### PR DESCRIPTION
This fixes all the warnings but one (38 out of 39) by modifying only the test files. The tests still pass