### PR TITLE
Johnfreeman/roland sipos/daphne stream frame v3.2.0 based

### DIFF
--- a/include/detdataformats/DAQHeader.hpp
+++ b/include/detdataformats/DAQHeader.hpp
@@ -11,6 +11,7 @@
 #define DETDATAFORMATS_INCLUDE_DETDATAFORMATS_DAQHEADER_HPP_
 
 #include <cstdint>
+#include <ostream>
 
 namespace dunedaq::detdataformats {
 

--- a/include/detdataformats/DAQHeader.hpp
+++ b/include/detdataformats/DAQHeader.hpp
@@ -1,0 +1,32 @@
+/**
+ * @file DAQHeader.hpp Common header structure that is used by 
+ * every FrontEnd electronics board.
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef DETDATAFORMATS_INCLUDE_DETDATAFORMATS_DAQHEADER_HPP_
+#define DETDATAFORMATS_INCLUDE_DETDATAFORMATS_DAQHEADER_HPP_
+
+#include <cstdint>
+
+namespace dunedaq::detdataformats {
+
+/**
+ * @brief DAQHeader is a versioned and unified structure for every FE electronics.
+ */
+struct DAQHeader 
+{
+  using word_t = uint32_t; // NOLINT(build/unsigned)
+
+  word_t version : 6, det_id : 6, crate_id : 10, slot_id : 4, link_id : 6;
+  word_t timestamp_1 : 32;
+  word_t timestamp_2 : 32;
+  
+};
+
+} // namespace dunedaq::detdataformats
+
+#endif // DETDATAFORMATS_INCLUDE_DETDATAFORMATS_DAQHEADER_HPP_

--- a/include/detdataformats/DAQHeader.hpp
+++ b/include/detdataformats/DAQHeader.hpp
@@ -24,8 +24,20 @@ struct DAQHeader
   word_t version : 6, det_id : 6, crate_id : 10, slot_id : 4, link_id : 6;
   word_t timestamp_1 : 32;
   word_t timestamp_2 : 32;
-  
+
+  uint64_t get_timestamp() const // NOLINT(build/unsigned)
+  {
+    return (uint64_t)timestamp_1 | ((uint64_t)timestamp_2 << 32); // NOLINT(build/unsigned)
+  } 
 };
+
+inline std::ostream&
+operator<<(std::ostream& o, DAQHeader const& h)
+{
+  return o << "Version:" << unsigned(h.version) << " DetID:" << unsigned(h.det_id) << " CrateID:" << unsigned(h.crate_id)
+           << " SlotID:" << unsigned(h.slot_id) << " LinkID:" << unsigned(h.link_id)
+           << " Timestamp: " << h.get_timestamp() << '\n';
+}
 
 } // namespace dunedaq::detdataformats
 

--- a/include/detdataformats/DAQHeader.hpp
+++ b/include/detdataformats/DAQHeader.hpp
@@ -28,7 +28,7 @@ struct DAQHeader
 
   uint64_t get_timestamp() const // NOLINT(build/unsigned)
   {
-    return (uint64_t)timestamp_1 | ((uint64_t)timestamp_2 << 32); // NOLINT(build/unsigned)
+    return uint64_t(timestamp_1) | (uint64_t(timestamp_2) << 32); // NOLINT(build/unsigned)
   } 
 };
 

--- a/include/detdataformats/daphne/DAPHNEStreamFrame.hpp
+++ b/include/detdataformats/daphne/DAPHNEStreamFrame.hpp
@@ -1,0 +1,92 @@
+/**
+ * @file DAPHNEStreamFrame.hpp
+ *
+ *  Contains declaration of DAPHNEStreamFrame, a class for accessing 
+ *  raw DAPHNE streaming version frames, as produced by the DAPHNE boards
+ *
+ *  The canonical definition of the PDS DAPHNE format is given in EDMS document 2088726:
+ *  https://edms.cern.ch/document/2088726/3
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef DETDATAFORMATS_INCLUDE_DATAFORMATS_DAPHNE_DAPHNESTREAMFRAME_HPP_
+#define DETDATAFORMATS_INCLUDE_DATAFORMATS_DAPHNE_DAPHNESTREAMFRAME_HPP_
+
+#include "detdataformats/DAQHeader.hpp" // For unified DAQ header
+
+#include <algorithm> // For std::min
+#include <cassert>   // For assert()
+#include <cstdio>
+#include <cstdlib>
+#include <stdexcept> // For std::out_of_range
+#include <cstdint>  // For uint32_t etc
+
+namespace dunedaq {
+namespace detdataformats {
+namespace daphne {
+
+class DAPHNEStreamFrame
+{
+public:
+  // ===============================================================
+  // Preliminaries
+  // ===============================================================
+
+  // The definition of the format is in terms of 32-bit words
+  typedef uint32_t word_t; // NOLINT
+
+  static constexpr int s_bits_per_adc = 14;
+  static constexpr int s_bits_per_word = 8 * sizeof(word_t);
+  static constexpr int s_channels_per_frame = 4;
+  static constexpr int s_adcs_per_channel = 64;
+  static constexpr int s_daphnes_per_frame = 1;
+  static constexpr int s_num_adc_words = s_channels_per_frame * s_adcs_per_channel * s_bits_per_adc / s_bits_per_word;
+
+  struct Header
+  {
+    word_t channel_0 : 6, channel_1 : 6, channel_2 : 6, channel_3 : 6, tbd_0 : 8;
+    word_t tbd_1 : 32;
+  };
+
+  struct Trailer
+  {
+    word_t tbd : 32;
+  };
+
+  // ===============================================================
+  // Data members
+  // ===============================================================
+  detdataformats::DAQHeader daq_header;
+  Header header;
+  word_t adc_words[s_num_adc_words]; // NOLINT
+  Trailer trailer; 
+
+  // ===============================================================
+  // Accessors
+  // ===============================================================
+
+  /**
+   * @brief Get the @p i ADC value of @p chn in the frame
+   */
+  uint16_t get_adc(int i, int chn) const // NOLINT
+  {
+    // RS FIXME: TBA
+  }
+
+  /**
+   * @brief Set the @p i ADC value of @p chn in the frame to @p val
+   */
+  void set_adc(int i, int chn, uint16_t val) // NOLINT
+  {
+    // RS FIXME: TBA
+  }
+};
+
+} // namespace daphne
+} // namespace detdataformats
+} // namespace dunedaq
+
+#endif // DETDATAFORMATS_INCLUDE_DATAFORMATS_DAPHNE_DAPHNESTREAMFRAME_HPP_

--- a/include/detdataformats/daphne/DAPHNEStreamFrame.hpp
+++ b/include/detdataformats/daphne/DAPHNEStreamFrame.hpp
@@ -68,18 +68,24 @@ public:
   // Accessors
   // ===============================================================
 
+  uint64_t get_timestamp() const 
+  {
+    return daq_header.get_timestamp();
+  }
+
   /**
    * @brief Get the @p i ADC value of @p chn in the frame
    */
-  uint16_t get_adc(int i, int chn) const // NOLINT
+  uint16_t get_adc(int /*i*/, int /*chn*/) const // NOLINT
   {
     // RS FIXME: TBA
+    return 0;
   }
 
   /**
    * @brief Set the @p i ADC value of @p chn in the frame to @p val
    */
-  void set_adc(int i, int chn, uint16_t val) // NOLINT
+  void set_adc(int /*i*/, int /*chn*/, uint16_t /*val*/) // NOLINT
   {
     // RS FIXME: TBA
   }

--- a/include/detdataformats/daphne/DAPHNEStreamFrame.hpp
+++ b/include/detdataformats/daphne/DAPHNEStreamFrame.hpp
@@ -73,6 +73,15 @@ public:
     return daq_header.get_timestamp();
   }
 
+  /** @brief Set the 64-bit timestamp of the frame
+  */
+  void set_timestamp(const uint64_t new_timestamp) // NOLINT(build/unsigned)
+  {
+    daq_header.timestamp_1 = new_timestamp;
+    daq_header.timestamp_2 = new_timestamp >> 32;
+  }
+
+
   /**
    * @brief Get the @p i ADC value of @p chn in the frame
    */

--- a/pybindsrc/daphne.cpp
+++ b/pybindsrc/daphne.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "detdataformats/daphne/DAPHNEFrame.hpp"
+#include "detdataformats/daphne/DAPHNEStreamFrame.hpp"
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -53,6 +54,47 @@ register_daphne(py::module& m)
     .def_property_readonly("flex_word_24", [](DAPHNEFrame::Trailer& self) -> uint32_t {return self.flex_word_24;})
   ;
 
+
+  py::class_<DAPHNEStreamFrame::Header>(m, "DAPHNEStreamHeader")
+    .def_property("channel_0", 
+      [](DAPHNEStreamFrame::Header& self) -> uint32_t { return self.channel_0; }, 
+      [](DAPHNEStreamFrame::Header& self, uint32_t channel_0) { self.channel_0 = channel_0; } 
+      )
+    .def_property("channel_1", 
+      [](DAPHNEStreamFrame::Header& self) -> uint32_t { return self.channel_1; }, 
+      [](DAPHNEStreamFrame::Header& self, uint32_t channel_1) { self.channel_1 = channel_1; } 
+      )
+    .def_property("channel_2", 
+      [](DAPHNEStreamFrame::Header& self) -> uint32_t { return self.channel_2; }, 
+      [](DAPHNEStreamFrame::Header& self, uint32_t channel_2) { self.channel_2 = channel_2; } 
+      )
+    .def_property("channel_3", 
+      [](DAPHNEStreamFrame::Header& self) -> uint32_t { return self.channel_3; }, 
+      [](DAPHNEStreamFrame::Header& self, uint32_t channel_3) { self.channel_3 = channel_3; } 
+      )
+  ;
+
+
+  py::class_<DAPHNEStreamFrame>(m, "DAPHNEStreamFrame", py::buffer_protocol())
+    .def(py::init())
+    .def(py::init([](py::capsule capsule) {
+        auto wfp = *static_cast<DAPHNEStreamFrame*>(capsule.get_pointer());
+        return wfp;
+    } ))
+    .def("get_daqheader", [](DAPHNEStreamFrame& self) -> const DAQHeader& {return self.daq_header;}, py::return_value_policy::reference_internal)
+    .def("get_header", [](DAPHNEStreamFrame& self) -> const DAPHNEStreamFrame::Header& {return self.header;}, py::return_value_policy::reference_internal)
+    .def("get_trailer", [](DAPHNEStreamFrame& self) -> const DAPHNEStreamFrame::Trailer& {return self.trailer;}, py::return_value_policy::reference_internal)
+    .def("get_timestamp", &DAPHNEStreamFrame::get_timestamp)
+    .def("set_timestamp", &DAPHNEStreamFrame::set_timestamp)
+    .def("get_adc", &DAPHNEStreamFrame::get_adc)
+    .def("set_adc", &DAPHNEStreamFrame::set_adc)
+    .def_static("sizeof", [](){ return sizeof(DAPHNEStreamFrame); })
+    .def("get_bytes",
+         [](DAPHNEStreamFrame* fr) -> py::bytes {
+           return py::bytes(reinterpret_cast<char*>(fr), sizeof(DAPHNEStreamFrame));
+        }
+    )
+  ;
 }
 
 } // namespace python

--- a/pybindsrc/daqheader.cpp
+++ b/pybindsrc/daqheader.cpp
@@ -1,0 +1,54 @@
+/**
+ * @file detid.cpp
+ *
+ * This is part of the DUNE DAQ Software Suite, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "submodules.hpp"
+#include "detdataformats/DAQHeader.hpp"
+
+#include <pybind11/operators.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <sstream>
+
+namespace py = pybind11;
+
+namespace dunedaq::detdataformats::python {
+
+void register_daqheader(py::module& m) {
+
+  py::class_<DAQHeader>(m, "DAQHeader", py::buffer_protocol())
+    // .def(py::init())
+    // .def(py::init([](py::capsule capsule) {
+    //     auto dhp = *static_cast<DAQHeader*>(capsule.get_pointer());
+    //     return dhp;
+    // } ))
+    .def_property("version", 
+      [](DAQHeader& self) -> uint32_t { return self.version; }, 
+      [](DAQHeader& self, uint32_t version) { self.version = version; } 
+      )
+    .def_property("det_id", 
+      [](DAQHeader& self) -> uint32_t { return self.det_id; }, 
+      [](DAQHeader& self, uint32_t det_id) { self.det_id = det_id; } 
+      )
+    .def_property("crate_id", 
+      [](DAQHeader& self) -> uint32_t { return self.crate_id; }, 
+      [](DAQHeader& self, uint32_t crate_id) { self.crate_id = crate_id; } 
+      )
+    .def_property("slot_id", 
+      [](DAQHeader& self) -> uint32_t { return self.slot_id; }, 
+      [](DAQHeader& self, uint32_t slot_id) { self.slot_id = slot_id; } 
+      )
+    .def_property("link_id", 
+      [](DAQHeader& self) -> uint32_t { return self.link_id; }, 
+      [](DAQHeader& self, uint32_t link_id) { self.link_id = link_id; } 
+      )
+    .def("get_timestamp", &DAQHeader::get_timestamp)
+    ;
+}
+
+}  // namespace dunedaq::detdataformats::python

--- a/pybindsrc/detid.cpp
+++ b/pybindsrc/detid.cpp
@@ -6,6 +6,7 @@
  * received with this code.
  */
 
+#include "submodules.hpp"
 #include "detdataformats/DetID.hpp"
 
 #include <pybind11/operators.h>
@@ -18,39 +19,36 @@ namespace py = pybind11;
 
 namespace dunedaq::detdataformats::python {
 
-    void
-        register_detid(py::module& m)
-    {
+void register_detid(py::module& m) {
+  py::class_<DetID> py_detid(m, "DetID");
+  py_detid.def(py::init())
+      .def(py::init<const DetID::Subdetector&>())
+      .def("__repr__", [](const DetID& gid) {
+        std::ostringstream oss;
+        oss << "<detdataformats::DetID " << gid.to_string() << ">";
+        return oss.str();
+      })
+      .def("to_string", &DetID::to_string)
+      .def("is_in_valid_state", &DetID::is_in_valid_state)
+      .def("subdetector_to_string", &DetID::subdetector_to_string)
+      .def("string_to_subdetector", &DetID::string_to_subdetector);
 
-        py::class_<DetID> py_detid(m, "DetID");
-        py_detid.def(py::init())
-            .def(py::init<const DetID::Subdetector&>() )
-        .def("__repr__", [](const DetID& gid) {
-            std::ostringstream oss;
-            oss << "<detdataformats::DetID " << gid.to_string() << ">";
-            return oss.str();
-            })
-            .def("to_string", &DetID::to_string)
-                .def("is_in_valid_state", &DetID::is_in_valid_state)
-                .def("subdetector_to_string", &DetID::subdetector_to_string)
-                .def("string_to_subdetector", &DetID::string_to_subdetector);
+  py::enum_<DetID::Subdetector>(py_detid, "Subdetector")
+      .value("kUnknown", DetID::Subdetector::kUnknown)
+      .value("kDAQ", DetID::Subdetector::kDAQ)
+      .value("kHD_PDS", DetID::Subdetector::kHD_PDS)
+      .value("kHD_TPC", DetID::Subdetector::kHD_TPC)
+      .value("kHD_CRT", DetID::Subdetector::kHD_CRT)
+      .value("kVD_CathodePDS", DetID::Subdetector::kVD_CathodePDS)
+      .value("kVD_MembranePDS", DetID::Subdetector::kVD_MembranePDS)
+      .value("kVD_BottomTPC", DetID::Subdetector::kVD_BottomTPC)
+      .value("kVD_TopTPC", DetID::Subdetector::kVD_TopTPC)
+      .value("kND_LAr", DetID::Subdetector::kND_LAr)
+      .value("kND_GAr", DetID::Subdetector::kND_GAr)
+      .export_values();
 
-        py::enum_<DetID::Subdetector>(py_detid, "Subdetector")
-            .value("kUnknown", DetID::Subdetector::kUnknown)
-            .value("kDAQ", DetID::Subdetector::kDAQ)
-            .value("kHD_PDS", DetID::Subdetector::kHD_PDS)
-            .value("kHD_TPC", DetID::Subdetector::kHD_TPC)
-            .value("kHD_CRT", DetID::Subdetector::kHD_CRT)
-            .value("kVD_CathodePDS", DetID::Subdetector::kVD_CathodePDS)
-            .value("kVD_MembranePDS", DetID::Subdetector::kVD_MembranePDS)
-            .value("kVD_BottomTPC", DetID::Subdetector::kVD_BottomTPC)
-            .value("kVD_TopTPC", DetID::Subdetector::kVD_TopTPC)
-            .value("kND_LAr", DetID::Subdetector::kND_LAr)
-            .value("kND_GAr", DetID::Subdetector::kND_GAr)
-            .export_values();
+  py_detid.def_readwrite("version", &DetID::version)
+      .def_readwrite("subdetector", &DetID::subdetector);
+}
 
-        py_detid.def_readwrite("version", &DetID::version)
-            .def_readwrite("subdetector", &DetID::subdetector);
-    }
-
-} // namespace dunedaq::detdataformats::python
+}  // namespace dunedaq::detdataformats::python

--- a/pybindsrc/module.cpp
+++ b/pybindsrc/module.cpp
@@ -8,60 +8,20 @@
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include "submodules.hpp"
 
 namespace py = pybind11;
 
-
-
 namespace dunedaq {
 namespace detdataformats {
-
-namespace wib {
 namespace python {
-extern void register_wib(py::module &);
-}
-}
-
-namespace wib2 {
-namespace python {
-  extern void register_wib2(py::module &);
-}
-}
-
-namespace daphne {
-namespace python {
-  extern void register_daphne(py::module &);
-}
-}
-
-namespace ssp {
-namespace python {
-extern void register_ssp(py::module &);    
-}
-}
-
-namespace trigger {
-namespace python {
-extern void register_trigger_primitive(py::module &);    
-}
-}
-
-namespace hsi {
-namespace python {
-extern void register_hsi(py::module &);    
-}
-}
-
-namespace python {
-
-    extern void
-        register_detid(py::module&);
 
 PYBIND11_MODULE(_daq_detdataformats_py, m) {
 
     m.doc() = "c++ implementation of the dunedaq detdataformats modules"; // optional module docstring
 
-    register_detid(m);
+    python::register_detid(m);
+    python::register_daqheader(m);
 
     py::module_ wib_module = m.def_submodule("wib");
     wib::python::register_wib(wib_module);

--- a/pybindsrc/submodules.hpp
+++ b/pybindsrc/submodules.hpp
@@ -1,0 +1,52 @@
+#ifndef __DUNEDAQ_DETDATAFORMATS_PYBINDSRC_SUBMODULES_HPP__
+#define __DUNEDAQ_DETDATAFORMATS_PYBINDSRC_SUBMODULES_HPP__ 
+
+#include <pybind11/pybind11.h>
+
+namespace dunedaq {
+namespace detdataformats {
+
+namespace python {
+void register_detid(pybind11::module &);
+void register_daqheader(pybind11::module &);
+}  // namespace python
+
+namespace wib {
+namespace python {
+extern void register_wib(pybind11::module &);
+}
+}  // namespace wib
+
+namespace wib2 {
+namespace python {
+extern void register_wib2(pybind11::module &);
+}
+}  // namespace wib2
+
+namespace daphne {
+namespace python {
+extern void register_daphne(pybind11::module &);
+}
+}  // namespace daphne
+
+namespace ssp {
+namespace python {
+extern void register_ssp(pybind11::module &);
+}
+}  // namespace ssp
+
+namespace trigger {
+namespace python {
+extern void register_trigger_primitive(pybind11::module &);
+}
+}  // namespace trigger
+
+namespace hsi {
+namespace python {
+extern void register_hsi(pybind11::module &);
+}
+}  // namespace hsi
+
+}  // namespace detdataformats
+}  // namespace dunedaq
+#endif /* __DUNEDAQ_DETDATAFORMATS_PYBINDSRC_SUBMODULES_HPP__ */


### PR DESCRIPTION
There's an existing PR #47 for the `roland-sipos/daphne-stream-frame` branch to be merged into `develop`; however we want the same functionality on `patch/v3.2.x` for the upcoming integration week. As there's unrelated functionality on `roland-sipos/daphne-stream-frame` introduced back in September/early October (i.e. since the `dunedaq-v3.2.0` release), this PR is designed cut out the unrelated functionality and  _only_ bring in:
1) The DAPHNE stream related functionality from `roland-sipos/daphne-stream-frame` 
2) The addition of the unified DAQ header (i.e., what was brought into `develop` from PR #44)
It's essentially the union of the commits from PR #44 and #47, meant to be applied to the patch branch. 