### PR TITLE
TDE python bindings and constructors from py::bytes

### DIFF
--- a/pybindsrc/daphne.cpp
+++ b/pybindsrc/daphne.cpp
@@ -29,6 +29,11 @@ register_daphne(py::module& m)
         auto wfp = *static_cast<DAPHNEFrame*>(capsule.get_pointer());
         return wfp;
     } ))
+    .def(py::init([](py::bytes bytes){
+      py::buffer_info info(py::buffer(bytes).request());
+      auto wfp = *static_cast<DAPHNEFrame*>(info.ptr);
+      return wfp;
+    }))
     .def("get_adc", static_cast<uint16_t (DAPHNEFrame::*)(const int) const>(&DAPHNEFrame::get_adc))
     .def("get_t", static_cast<uint16_t (DAPHNEFrame::*)(const int) const>(&DAPHNEFrame::get_t))
     .def("get_timestamp", &DAPHNEFrame::get_timestamp)

--- a/pybindsrc/hsi.cpp
+++ b/pybindsrc/hsi.cpp
@@ -27,6 +27,11 @@ register_hsi(py::module& m)
         auto hsfp = *static_cast<TimingHSIFrame*>(capsule.get_pointer());
         return hsfp;
     } ))
+    .def(py::init([](py::bytes bytes){
+      py::buffer_info info(py::buffer(bytes).request());
+      auto wfp = *static_cast<TimingHSIFrame*>(info.ptr);
+      return wfp;
+    }))
     .def("get_timestamp", &TimingHSIFrame::get_timestamp)
     .def_property_readonly("version", [](const TimingHSIFrame& self) -> uint64_t {return self.version;})
     .def_property_readonly("detector_id", [](const TimingHSIFrame& self) -> uint64_t {return self.detector_id;})

--- a/pybindsrc/module.cpp
+++ b/pybindsrc/module.cpp
@@ -40,6 +40,9 @@ PYBIND11_MODULE(_daq_detdataformats_py, m) {
 
     py::module_ hsi_module = m.def_submodule("hsi");
     hsi::python::register_hsi(hsi_module);
+
+    py::module_ tde_module = m.def_submodule("tde");
+    tde::python::register_tde(tde_module);
 }
 
 } // namespace python

--- a/pybindsrc/submodules.hpp
+++ b/pybindsrc/submodules.hpp
@@ -47,6 +47,14 @@ extern void register_hsi(pybind11::module &);
 }
 }  // namespace hsi
 
+
+namespace tde {
+namespace python {
+extern void register_tde(pybind11::module &);
+}
+}  // namespace tde
+
+
 }  // namespace detdataformats
 }  // namespace dunedaq
 #endif /* __DUNEDAQ_DETDATAFORMATS_PYBINDSRC_SUBMODULES_HPP__ */

--- a/pybindsrc/tde.cpp
+++ b/pybindsrc/tde.cpp
@@ -1,0 +1,56 @@
+/**
+ * @file wib2.cpp Python bindings for the TDE16Frame format
+ *
+ * This is part of the DUNE DAQ Software Suite, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "detdataformats/tde/TDE16Frame.hpp"
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+namespace py = pybind11;
+
+namespace dunedaq {
+namespace detdataformats {
+namespace tde {
+namespace python {
+
+void
+register_tde(py::module& m)
+{
+
+  py::class_<TDE16Frame>(m, "TDE16Frame", py::buffer_protocol())
+    .def(py::init())
+    .def(py::init([](py::capsule capsule) {
+        auto wfp = *static_cast<TDE16Frame*>(capsule.get_pointer());
+        return wfp;
+    } ))
+    .def("get_timestamp", &TDE16Frame::get_timestamp)
+    .def("set_timestamp", &TDE16Frame::set_timestamp)
+    .def("get_tde_header", [](TDE16Frame& self) -> TDE16Header* {return self.get_tde_header();}, py::return_value_policy::reference_internal)
+    .def_static("sizeof", [](){ return sizeof(TDE16Frame); })
+    .def("get_bytes",
+         [](TDE16Frame* fr) -> py::bytes {
+           return py::bytes(reinterpret_cast<char*>(fr), sizeof(TDE16Frame));
+        }
+    )
+  ;
+
+  py::class_<TDE16Header>(m, "TDE16Header")
+    .def_property_readonly("version", [](TDE16Header& self) -> uint32_t {return self.version;})
+    .def_property_readonly("det_id", [](TDE16Header& self) -> uint32_t {return self.det_id;})
+    .def_property_readonly("crate", [](TDE16Header& self) -> uint32_t {return self.crate;})
+    .def_property_readonly("slot", [](TDE16Header& self) -> uint32_t {return self.slot;})
+    .def_property_readonly("link", [](TDE16Header& self) -> uint32_t {return self.link;})
+    .def_property_readonly("timestamp_1", [](TDE16Header& self) -> uint32_t {return self.timestamp_1;})
+    .def_property_readonly("timestamp_2", [](TDE16Header& self) -> uint32_t {return self.timestamp_2;})
+  ;
+}
+
+} // namespace python
+} // namespace wib2
+} // namespace detdataformats
+} // namespace dunedaq

--- a/pybindsrc/tde.cpp
+++ b/pybindsrc/tde.cpp
@@ -28,6 +28,11 @@ register_tde(py::module& m)
         auto wfp = *static_cast<TDE16Frame*>(capsule.get_pointer());
         return wfp;
     } ))
+    .def(py::init([](py::bytes bytes){
+      py::buffer_info info(py::buffer(bytes).request());
+      auto wfp = *static_cast<TDE16Frame*>(info.ptr);
+      return wfp;
+    }))
     .def("get_timestamp", &TDE16Frame::get_timestamp)
     .def("set_timestamp", &TDE16Frame::set_timestamp)
     .def("get_tde_header", [](TDE16Frame& self) -> TDE16Header* {return self.get_tde_header();}, py::return_value_policy::reference_internal)

--- a/pybindsrc/wib.cpp
+++ b/pybindsrc/wib.cpp
@@ -28,6 +28,11 @@ register_wib(py::module& m)
         auto wfp = *static_cast<WIBFrame*>(capsule.get_pointer());
         return wfp;
     } ))
+    .def(py::init([](py::bytes bytes){
+      py::buffer_info info(py::buffer(bytes).request());
+      auto wfp = *static_cast<WIBFrame*>(info.ptr);
+      return wfp;
+    }))
     .def("get_wib_header", static_cast<const WIBHeader* (WIBFrame::*)() const >(&WIBFrame::get_wib_header), py::return_value_policy::reference_internal)
     .def("get_coldata_header", &WIBFrame::get_coldata_header, py::return_value_policy::reference_internal)
     .def("get_block", &WIBFrame::get_block, py::return_value_policy::reference_internal)

--- a/pybindsrc/wib2.cpp
+++ b/pybindsrc/wib2.cpp
@@ -56,8 +56,8 @@ register_wib2(py::module& m)
     .def_property_readonly("femb_pulser_frame_bits", [](WIB2Frame::Header& self) -> uint32_t {return self.femb_pulser_frame_bits;})
     .def_property_readonly("femb_sync_flags", [](WIB2Frame::Header& self) -> uint32_t {return self.femb_sync_flags;})
     .def_property_readonly("colddata_timestamp", [](WIB2Frame::Header& self) -> uint32_t {return self.colddata_timestamp;})
-
   ;
+  
   py::class_<WIB2Frame::Trailer>(m, "WIB2Trailer")
     .def_property_readonly("flex_bits", [](WIB2Frame::Trailer& self) -> uint32_t {return self.flex_bits;})
     .def_property_readonly("ws", [](WIB2Frame::Trailer& self) -> uint32_t {return self.ws;})

--- a/pybindsrc/wib2.cpp
+++ b/pybindsrc/wib2.cpp
@@ -28,6 +28,11 @@ register_wib2(py::module& m)
         auto wfp = *static_cast<WIB2Frame*>(capsule.get_pointer());
         return wfp;
     } ))
+    .def(py::init([](py::bytes bytes){
+      py::buffer_info info(py::buffer(bytes).request());
+      auto wfp = *static_cast<WIB2Frame*>(info.ptr);
+      return wfp;
+    }))
     .def("get_adc", static_cast<uint16_t (WIB2Frame::*)(const int) const>(&WIB2Frame::get_adc))
     .def("set_adc", static_cast<void (WIB2Frame::*)(int, uint16_t)>(&WIB2Frame::set_adc))
     .def("get_timestamp", &WIB2Frame::get_timestamp)

--- a/python/detdataformats/tde/__init__.py
+++ b/python/detdataformats/tde/__init__.py
@@ -1,0 +1,1 @@
+from .._daq_detdataformats_py.tde import *


### PR DESCRIPTION
This PR adds python bindings for TDE16Frames and also constructors "from py::bytes" to all overlay classes