### PR TITLE
Adding new algorithm type for Custom Trigger Candidate Maker

### DIFF
--- a/include/detdataformats/trigger/TriggerCandidateData.hpp
+++ b/include/detdataformats/trigger/TriggerCandidateData.hpp
@@ -42,7 +42,8 @@ struct TriggerCandidateData
     kADCSimpleWindow = 4,
     kHorizontalMuon = 5,
     kMichelElectron = 6, 
-    kLowEnergyEvent = 7, 
+    kLowEnergyEvent = 7,
+    kCustom = 8, 
   };
 
   // Update this version number if there are any changes to the in-memory representation of this class!


### PR DESCRIPTION
New algorithm type for Trigger Candidate termed "kCustom" which is used to flag TCs made by the Custom Trigger Candidate Maker.