### PR TITLE
Added a PyBind to Get HSIFrame Data Size.

### DIFF
--- a/pybindsrc/hsi.cpp
+++ b/pybindsrc/hsi.cpp
@@ -39,6 +39,7 @@ register_hsi(py::module& m)
     .def_property_readonly("input_high", [](const HSIFrame& self) -> uint64_t {return self.input_high;})
     .def_property_readonly("trigger", [](const HSIFrame& self) -> uint64_t {return self.trigger;})
     .def_property_readonly("sequence", [](const HSIFrame& self) -> uint64_t {return self.sequence;})
+    .def_static("sizeof", [](){ return sizeof(HSIFrame); })
   ;
 }
 


### PR DESCRIPTION
I've added a `sizeof()` static function method to the Python binding to get the size of the HSIFrames.

The HSIFrame size was unavailable and made it difficult to iterate through HSI fragments. Either the value had to be known or derivable from the pythonic `sizeof`. However, deriving is difficult because the Python bindings also inflate the size of this object compared to what is in C++ (the HDF5 file).

I tested the use of this in interactive Python and found no issues.