### PR TITLE
Normalising detid strings

### DIFF
--- a/include/detdataformats/detail/DetID.hxx
+++ b/include/detdataformats/detail/DetID.hxx
@@ -76,13 +76,13 @@ DetID::subdetector_to_string(const Subdetector& type)
     case Subdetector::kHD_CRT:
       return "HD_CRT";
     case Subdetector::kVD_CathodePDS:
-      return "VD_Cathode_PDS";
+      return "VD_CathodePDS";
     case Subdetector::kVD_MembranePDS:
-      return "VD_Membrane_PDS";
+      return "VD_MembranePDS";
     case Subdetector::kVD_BottomTPC:
-      return "VD_Bottom_TPC";
+      return "VD_BottomTPC";
     case Subdetector::kVD_TopTPC:
-      return "VD_Top_TPC";
+      return "VD_TopTPC";
     case Subdetector::kVD_BernCRT:
       return "VD_BernCRT";
     case Subdetector::kVD_GrenobleCRT:
@@ -109,13 +109,13 @@ DetID::string_to_subdetector(const std::string& typestring)
     return Subdetector::kHD_TPC;
   if (typestring == "HD_CRT")
     return Subdetector::kHD_CRT;
-  if (typestring == "VD_Cathode_PDS")
+  if (typestring == "VD_CathodePDS")
     return Subdetector::kVD_CathodePDS;
-  if (typestring == "VD_Membrane_PDS")
+  if (typestring == "VD_MembranePDS")
     return Subdetector::kVD_MembranePDS;
-  if (typestring == "VD_Bottom_TPC")
+  if (typestring == "VD_BottomTPC")
     return Subdetector::kVD_BottomTPC;
-  if (typestring == "VD_Top_TPC")
+  if (typestring == "VD_TopTPC")
     return Subdetector::kVD_TopTPC;
   if (typestring == "VD_BernCRT")
     return Subdetector::kVD_BernCRT;


### PR DESCRIPTION
Linked PR: https://github.com/DUNE-DAQ/rawdatautils/pull/104

An issue was discovered with the inconsistency in string names for the DetID enum. 
This PR changes the 'outlier' names to match the enum names exactly. 

I did try to search the whole `$DUNE_DAQ_RELEASE_SOURCE` for the 4 strings that are changed, but would appreciate somebody else confirming this. 

Passed `dbt-unittest-summary.sh` and `daqsystemtest_integtest_bundle.sh`.