### PR TITLE
Adding DAQ Eth Header python constructor

### DIFF
--- a/pybindsrc/daqethheader.cpp
+++ b/pybindsrc/daqethheader.cpp
@@ -21,6 +21,15 @@ namespace dunedaq::detdataformats::python {
 void register_daqethheader(py::module& m) {
 
   py::class_<DAQEthHeader>(m, "DAQEthHeader", py::buffer_protocol())
+    .def(py::init([](py::capsule capsule) {
+        auto hsfp = *static_cast<DAQEthHeader*>(capsule.get_pointer());
+        return hsfp;
+    } ))
+    .def(py::init([](py::bytes bytes){
+      py::buffer_info info(py::buffer(bytes).request());
+      auto wfp = *static_cast<DAQEthHeader*>(info.ptr);
+      return wfp;
+    }))
     .def_property("version", 
       [](DAQEthHeader& self) -> uint32_t { return self.version; }, 
       [](DAQEthHeader& self, uint32_t version) { self.version = version; } 


### PR DESCRIPTION
Exposes the DAQ Eth Header python constructor to enable inspection of DAQ Frames without a-priori knowledge of the payload.
Used for DAPHNE Eth validation.

Part of https://github.com/DUNE-DAQ/fdreadoutlibs/issues/280