### PR TITLE
Johnfreeman/detdataformats issue100 code refactoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,9 @@ daq_add_python_bindings(*.cpp)
 ##############################################################################
 # Unit Tests
 daq_add_unit_test(DetID_test                LINK_LIBRARIES detdataformats)
+daq_add_unit_test(HSIFrame_test             LINK_LIBRARIES detdataformats)
+daq_add_unit_test(DAQHeader_test            LINK_LIBRARIES detdataformats)
+daq_add_unit_test(DAQEthHeader_test         LINK_LIBRARIES detdataformats)
 ##############################################################################
 
 daq_install()

--- a/include/detdataformats/DAQEthHeader.hpp
+++ b/include/detdataformats/DAQEthHeader.hpp
@@ -26,9 +26,9 @@ struct DAQEthHeader
   word_t version : 6, det_id : 6, crate_id : 10, slot_id : 4, stream_id : 8, reserved : 6, seq_id : 12, block_length : 12;
   word_t timestamp { std::numeric_limits<word_t>::max() };
 
-  uint64_t get_timestamp() const // NOLINT(build/unsigned)
+  uint64_t get_timestamp() const // NOLINT(build/unsigned) maintain a consistent interface with DAQHeader
   {
-    return uint64_t(timestamp); // NOLINT(build/unsigned)
+    return timestamp;
   } 
 };
 

--- a/include/detdataformats/DAQEthHeader.hpp
+++ b/include/detdataformats/DAQEthHeader.hpp
@@ -32,14 +32,7 @@ struct DAQEthHeader
   } 
 };
 
-inline std::ostream&
-operator<<(std::ostream& o, DAQEthHeader const& h)
-{
-  return o << "Version:" << unsigned(h.version) << " DetID:" << unsigned(h.det_id) << " CrateID:" << unsigned(h.crate_id)
-           << " SlotID:" << unsigned(h.slot_id) << " StreamID:" << unsigned(h.stream_id)
-           << " SequenceID: " << unsigned(h.seq_id) << " Block length: " << unsigned(h.block_length)
-	   << " Timestamp: " << h.get_timestamp() << '\n';
-}
+std::ostream& operator<<(std::ostream& o, DAQEthHeader const& h);
 
 } // namespace dunedaq::detdataformats
 

--- a/include/detdataformats/DAQEthHeader.hpp
+++ b/include/detdataformats/DAQEthHeader.hpp
@@ -11,6 +11,7 @@
 #define DETDATAFORMATS_INCLUDE_DETDATAFORMATS_DAQETHHEADER_HPP_
 
 #include <cstdint>
+#include <limits>
 #include <ostream>
 
 namespace dunedaq::detdataformats {
@@ -23,7 +24,7 @@ struct DAQEthHeader
   using word_t = uint64_t; // NOLINT(build/unsigned)
 
   word_t version : 6, det_id : 6, crate_id : 10, slot_id : 4, stream_id : 8, reserved : 6, seq_id : 12, block_length : 12;
-  word_t timestamp;
+  word_t timestamp { std::numeric_limits<word_t>::max() };
 
   uint64_t get_timestamp() const // NOLINT(build/unsigned)
   {

--- a/include/detdataformats/DAQEthHeader.hpp
+++ b/include/detdataformats/DAQEthHeader.hpp
@@ -23,7 +23,7 @@ struct DAQEthHeader
   using word_t = uint64_t; // NOLINT(build/unsigned)
 
   word_t version : 6, det_id : 6, crate_id : 10, slot_id : 4, stream_id : 8, reserved : 6, seq_id : 12, block_length : 12;
-  word_t timestamp : 64;
+  word_t timestamp;
 
   uint64_t get_timestamp() const // NOLINT(build/unsigned)
   {
@@ -41,5 +41,7 @@ operator<<(std::ostream& o, DAQEthHeader const& h)
 }
 
 } // namespace dunedaq::detdataformats
+
+#include "detail/DAQEthHeader.hxx"
 
 #endif // DETDATAFORMATS_INCLUDE_DETDATAFORMATS_DAQETHHEADER_HPP_

--- a/include/detdataformats/DAQHeader.hpp
+++ b/include/detdataformats/DAQHeader.hpp
@@ -11,6 +11,7 @@
 #define DETDATAFORMATS_INCLUDE_DETDATAFORMATS_DAQHEADER_HPP_
 
 #include <cstdint>
+#include <limits>
 #include <ostream>
 
 namespace dunedaq::detdataformats {
@@ -23,8 +24,8 @@ struct DAQHeader
   using word_t = uint32_t; // NOLINT(build/unsigned)
 
   word_t version : 6, det_id : 6, crate_id : 10, slot_id : 4, link_id : 6;
-  word_t timestamp_1;
-  word_t timestamp_2;
+  word_t timestamp_1 { std::numeric_limits<word_t>::max() };
+  word_t timestamp_2 { std::numeric_limits<word_t>::max() };
 
   uint64_t get_timestamp() const // NOLINT(build/unsigned)
   {

--- a/include/detdataformats/DAQHeader.hpp
+++ b/include/detdataformats/DAQHeader.hpp
@@ -23,8 +23,8 @@ struct DAQHeader
   using word_t = uint32_t; // NOLINT(build/unsigned)
 
   word_t version : 6, det_id : 6, crate_id : 10, slot_id : 4, link_id : 6;
-  word_t timestamp_1 : 32;
-  word_t timestamp_2 : 32;
+  word_t timestamp_1;
+  word_t timestamp_2;
 
   uint64_t get_timestamp() const // NOLINT(build/unsigned)
   {
@@ -41,5 +41,7 @@ operator<<(std::ostream& o, DAQHeader const& h)
 }
 
 } // namespace dunedaq::detdataformats
+
+#include "detail/DAQHeader.hxx"
 
 #endif // DETDATAFORMATS_INCLUDE_DETDATAFORMATS_DAQHEADER_HPP_

--- a/include/detdataformats/DAQHeader.hpp
+++ b/include/detdataformats/DAQHeader.hpp
@@ -33,13 +33,7 @@ struct DAQHeader
   } 
 };
 
-inline std::ostream&
-operator<<(std::ostream& o, DAQHeader const& h)
-{
-  return o << "Version:" << unsigned(h.version) << " DetID:" << unsigned(h.det_id) << " CrateID:" << unsigned(h.crate_id)
-           << " SlotID:" << unsigned(h.slot_id) << " LinkID:" << unsigned(h.link_id)
-           << " Timestamp: " << h.get_timestamp() << '\n';
-}
+std::ostream& operator<<(std::ostream& o, DAQHeader const& h);
 
 } // namespace dunedaq::detdataformats
 

--- a/include/detdataformats/DAQHeader.hpp
+++ b/include/detdataformats/DAQHeader.hpp
@@ -29,7 +29,7 @@ struct DAQHeader
 
   uint64_t get_timestamp() const // NOLINT(build/unsigned)
   {
-    return uint64_t(timestamp_1) | (uint64_t(timestamp_2) << 32); // NOLINT(build/unsigned)
+    return static_cast<uint64_t>(timestamp_1) | (static_cast<uint64_t>(timestamp_2) << 32); // NOLINT(build/unsigned)
   } 
 };
 

--- a/include/detdataformats/DetID.hpp
+++ b/include/detdataformats/DetID.hpp
@@ -63,10 +63,13 @@ struct DetID
     : subdetector(subdetector_arg)
   {}
 
-  inline static std::string subdetector_to_string(const Subdetector& type);
-  inline static Subdetector string_to_subdetector(const std::string& typestring);
+  static std::string subdetector_to_string(const Subdetector& type);
+  static Subdetector string_to_subdetector(const std::string& typestring);
 };
 
+  std::ostream& operator<<(std::ostream& o, DetID const& det_id);
+  std::istream& operator>>(std::istream& is, DetID& det_id);
+  
 } // namespace dunedaq::detdataformats
 
 #include "detail/DetID.hxx"

--- a/include/detdataformats/DetID.hpp
+++ b/include/detdataformats/DetID.hpp
@@ -23,18 +23,16 @@
 namespace dunedaq::detdataformats {
 
 /**
- * @brief DetID is a versioned structure containing the 6 bits field of the unique identifier for a subdetector in the raw data.
+ * @brief DetID is a structure containing the 6 bits field of the unique identifier for a subdetector in the raw data.
  * For convenience this field is expanded to 16 bits.
  */
 struct DetID
 {
-  using Subdetector_t = uint16_t; // NOLINT(build/unsigned)
-
   /**
    * @brief The Subdetector enum describes the kind of source we're dealing with
    */
 
-  enum class Subdetector : Subdetector_t
+  enum class Subdetector : uint16_t // NOLINT(build/unsigned)
   {
     kUnknown = 0,
     kDAQ = 1,
@@ -59,9 +57,9 @@ struct DetID
 
   DetID() = default;
 
-  DetID(const Subdetector& subdetector_arg)
-    : subdetector(subdetector_arg)
-  {}
+  DetID(const Subdetector& subdetector_arg) // NOLINT(runtime/explicit) as DetID is just an enhanced enum
+     : subdetector(subdetector_arg)
+   {}
 
   static std::string subdetector_to_string(const Subdetector& type);
   static Subdetector string_to_subdetector(const std::string& typestring);
@@ -69,7 +67,7 @@ struct DetID
 
   std::ostream& operator<<(std::ostream& o, DetID const& det_id);
   std::istream& operator>>(std::istream& is, DetID& det_id);
-  
+
 } // namespace dunedaq::detdataformats
 
 #include "detail/DetID.hxx"

--- a/include/detdataformats/DetID.hpp
+++ b/include/detdataformats/DetID.hpp
@@ -28,8 +28,6 @@ namespace dunedaq::detdataformats {
  */
 struct DetID
 {
-
-  using Version_t = uint16_t;   // NOLINT(build/unsigned)
   using Subdetector_t = uint16_t; // NOLINT(build/unsigned)
 
   /**
@@ -55,15 +53,6 @@ struct DetID
   };
 
   /**
-   * @brief The version of this DetID struct.
-   */
-  static constexpr Version_t s_det_id_version = 1;
-
-  /**
-   * @brief Version number of the DetID
-   */
-  Version_t version{ s_det_id_version };
-  /**
    * @brief The general subdetector of the source of the data
    */
   Subdetector subdetector{ Subdetector::kUnknown };
@@ -73,15 +62,6 @@ struct DetID
   DetID(const Subdetector& subdetector_arg)
     : subdetector(subdetector_arg)
   {}
-
-  std::string to_string() const
-  {
-    std::ostringstream ostr;
-    ostr << subdetector_to_string(subdetector);
-    return ostr.str();
-  }
-
-  bool is_in_valid_state() const noexcept { return subdetector != Subdetector::kUnknown; }
 
   inline static std::string subdetector_to_string(const Subdetector& type);
   inline static Subdetector string_to_subdetector(const std::string& typestring);

--- a/include/detdataformats/HSIFrame.hpp
+++ b/include/detdataformats/HSIFrame.hpp
@@ -8,8 +8,8 @@
  * received with this code.
  */
 
-#ifndef DETDATAFORMATS_INCLUDE_HSIFRAME_HPP_
-#define DETDATAFORMATS_INCLUDE_HSIFRAME_HPP_
+#ifndef DETDATAFORMATS_INCLUDE_DETDATAFORMATS_HSIFRAME_HPP_
+#define DETDATAFORMATS_INCLUDE_DETDATAFORMATS_HSIFRAME_HPP_
 
 #include <cstdint>  // For uint32_t etc
 #include <limits>
@@ -20,8 +20,8 @@ class HSIFrame
 {
 public:
   // The definition of the format is in terms of 32-bit words
-  typedef uint32_t word_t; // NOLINT
-  
+  using word_t = uint32_t; // NOLINT
+
   word_t version : 6, detector_id : 6, crate : 10, slot : 4, link : 6;
   word_t timestamp_low { std::numeric_limits<word_t>::max() } ;
   word_t timestamp_high { std::numeric_limits<word_t>::max() } ;
@@ -32,7 +32,7 @@ public:
 
   uint64_t get_timestamp() const // NOLINT(build/unsigned)
   {
-    return (uint64_t)timestamp_low | ((uint64_t)timestamp_high << 32); // NOLINT(build/unsigned)
+    return static_cast<uint64_t>(timestamp_low) | (static_cast<uint64_t>(timestamp_high) << 32); // NOLINT(build/unsigned)
   }
 
   void set_timestamp(uint64_t ts) // NOLINT(build/unsigned)
@@ -46,8 +46,4 @@ public:
 
 #include "detail/HSIFrame.hxx"
 
-#endif // DETDATAFORMATS_INCLUDE_HSIFRAME_HPP_
-
-// Local Variables:
-// c-basic-offset: 2
-// End:
+#endif // DETDATAFORMATS_INCLUDE_DETDATAFORMATS_HSIFRAME_HPP_

--- a/include/detdataformats/HSIFrame.hpp
+++ b/include/detdataformats/HSIFrame.hpp
@@ -12,6 +12,7 @@
 #define DETDATAFORMATS_INCLUDE_HSIFRAME_HPP_
 
 #include <cstdint>  // For uint32_t etc
+#include <limits>
 
 namespace dunedaq::detdataformats {
 
@@ -22,12 +23,12 @@ public:
   typedef uint32_t word_t; // NOLINT
   
   word_t version : 6, detector_id : 6, crate : 10, slot : 4, link : 6;
-  word_t timestamp_low;
-  word_t timestamp_high;
-  word_t input_low;
-  word_t input_high;
-  word_t trigger;
-  word_t sequence;
+  word_t timestamp_low { std::numeric_limits<word_t>::max() } ;
+  word_t timestamp_high { std::numeric_limits<word_t>::max() } ;
+  word_t input_low { std::numeric_limits<word_t>::max() } ;
+  word_t input_high { std::numeric_limits<word_t>::max() } ;
+  word_t trigger { std::numeric_limits<word_t>::max() } ;
+  word_t sequence { std::numeric_limits<word_t>::max() } ;
 
   uint64_t get_timestamp() const // NOLINT(build/unsigned)
   {
@@ -40,7 +41,7 @@ public:
     timestamp_high = ts >> 32;
   }
 };
-  
+
 } // namespace dunedaq::detdataformats
 
 #include "detail/HSIFrame.hxx"

--- a/include/detdataformats/HSIFrame.hpp
+++ b/include/detdataformats/HSIFrame.hpp
@@ -22,12 +22,12 @@ public:
   typedef uint32_t word_t; // NOLINT
   
   word_t version : 6, detector_id : 6, crate : 10, slot : 4, link : 6;
-  word_t timestamp_low : 32;
-  word_t timestamp_high : 32;
-  word_t input_low : 32;
-  word_t input_high : 32;
-  word_t trigger : 32;
-  word_t sequence : 32;
+  word_t timestamp_low;
+  word_t timestamp_high;
+  word_t input_low;
+  word_t input_high;
+  word_t trigger;
+  word_t sequence;
 
   uint64_t get_timestamp() const // NOLINT(build/unsigned)
   {
@@ -40,8 +40,10 @@ public:
     timestamp_high = ts >> 32;
   }
 };
-
+  
 } // namespace dunedaq::detdataformats
+
+#include "detail/HSIFrame.hxx"
 
 #endif // DETDATAFORMATS_INCLUDE_HSIFRAME_HPP_
 

--- a/include/detdataformats/detail/DAQEthHeader.hxx
+++ b/include/detdataformats/detail/DAQEthHeader.hxx
@@ -1,0 +1,12 @@
+
+namespace dunedaq::detdataformats {
+
+  static_assert(std::endian::native == std::endian::little);
+
+  static_assert(std::is_trivially_copyable_v<DAQEthHeader>, "DAQEthHeader isn't trivially copyable and can't be safely std::memcpy'd");
+  static_assert(std::is_standard_layout_v<DAQEthHeader>, "DAQEthHeader isn't standard layout; reinterpret_cast and offsetof can't safely be used with it");
+
+  static_assert(sizeof(DAQEthHeader) == 16);
+  static_assert(offsetof(DAQEthHeader, timestamp) == 8, "timestamp field not at expected offset");
+
+} // namespace dunedaq::detdataformats

--- a/include/detdataformats/detail/DAQEthHeader.hxx
+++ b/include/detdataformats/detail/DAQEthHeader.hxx
@@ -9,4 +9,13 @@ namespace dunedaq::detdataformats {
   static_assert(sizeof(DAQEthHeader) == 16, "DAQEthHeader not the expected size");
   static_assert(offsetof(DAQEthHeader, timestamp) == 8, "timestamp field not at expected offset");
 
+  inline std::ostream&
+  operator<<(std::ostream& o, DAQEthHeader const& h)
+  {
+    return o << "Version:" << unsigned(h.version) << " DetID:" << unsigned(h.det_id) << " CrateID:" << unsigned(h.crate_id)
+           << " SlotID:" << unsigned(h.slot_id) << " StreamID:" << unsigned(h.stream_id)
+           << " SequenceID: " << unsigned(h.seq_id) << " Block length: " << unsigned(h.block_length)
+	   << " Timestamp: " << h.get_timestamp() << '\n';
+  }
+
 } // namespace dunedaq::detdataformats

--- a/include/detdataformats/detail/DAQEthHeader.hxx
+++ b/include/detdataformats/detail/DAQEthHeader.hxx
@@ -12,10 +12,15 @@ namespace dunedaq::detdataformats {
   inline std::ostream&
   operator<<(std::ostream& o, DAQEthHeader const& h)
   {
-    return o << "Version:" << unsigned(h.version) << " DetID:" << unsigned(h.det_id) << " CrateID:" << unsigned(h.crate_id)
-           << " SlotID:" << unsigned(h.slot_id) << " StreamID:" << unsigned(h.stream_id)
-           << " SequenceID: " << unsigned(h.seq_id) << " Block length: " << unsigned(h.block_length)
-	   << " Timestamp: " << h.get_timestamp() << '\n';
+    return o << "Version:" << static_cast<unsigned>(h.version) <<
+      " DetID:" << static_cast<unsigned>(h.det_id) <<
+      " CrateID:" << static_cast<unsigned>(h.crate_id) <<
+	" SlotID:" << static_cast<unsigned>(h.slot_id) <<
+	  " StreamID:" << static_cast<unsigned>(h.stream_id) <<
+	    " SequenceID: " << static_cast<unsigned>(h.seq_id) <<
+	      " Block length: " << static_cast<unsigned>(h.block_length) <<
+	      " Timestamp: " << h.get_timestamp() <<
+	      '\n';
   }
 
 } // namespace dunedaq::detdataformats

--- a/include/detdataformats/detail/DAQEthHeader.hxx
+++ b/include/detdataformats/detail/DAQEthHeader.hxx
@@ -1,12 +1,12 @@
 
 namespace dunedaq::detdataformats {
 
-  static_assert(std::endian::native == std::endian::little);
+  static_assert(std::endian::native == std::endian::little, "The DAQEthHeader bitfield layout assumes little-endian architecture");
 
   static_assert(std::is_trivially_copyable_v<DAQEthHeader>, "DAQEthHeader isn't trivially copyable and can't be safely std::memcpy'd");
   static_assert(std::is_standard_layout_v<DAQEthHeader>, "DAQEthHeader isn't standard layout; reinterpret_cast and offsetof can't safely be used with it");
 
-  static_assert(sizeof(DAQEthHeader) == 16);
+  static_assert(sizeof(DAQEthHeader) == 16, "DAQEthHeader not the expected size");
   static_assert(offsetof(DAQEthHeader, timestamp) == 8, "timestamp field not at expected offset");
 
 } // namespace dunedaq::detdataformats

--- a/include/detdataformats/detail/DAQHeader.hxx
+++ b/include/detdataformats/detail/DAQHeader.hxx
@@ -18,9 +18,13 @@ static_assert(offsetof(DAQHeader, timestamp_2) == 8, "DAQHeader timestamp_2 fiel
 inline std::ostream&
 operator<<(std::ostream& o, DAQHeader const& h)
 {
-  return o << "Version:" << unsigned(h.version) << " DetID:" << unsigned(h.det_id) << " CrateID:" << unsigned(h.crate_id)
-           << " SlotID:" << unsigned(h.slot_id) << " LinkID:" << unsigned(h.link_id)
-           << " Timestamp: " << h.get_timestamp() << '\n';
+  return o << "Version:" << static_cast<unsigned>(h.version) <<
+    " DetID:" << static_cast<unsigned>(h.det_id) <<
+    " CrateID:" << static_cast<unsigned>(h.crate_id) <<
+    " SlotID:" << static_cast<unsigned>(h.slot_id) <<
+      " LinkID:" << static_cast<unsigned>(h.link_id) <<
+      " Timestamp: " << h.get_timestamp() <<
+      '\n';
 }
 
 } // namespace dunedaq::detdataformats

--- a/include/detdataformats/detail/DAQHeader.hxx
+++ b/include/detdataformats/detail/DAQHeader.hxx
@@ -1,0 +1,13 @@
+
+namespace dunedaq::detdataformats {
+
+  static_assert(std::endian::native == std::endian::little);
+
+  static_assert(std::is_trivially_copyable_v<DAQHeader>, "DAQHeader isn't trivially copyable and can't be safely std::memcpy'd");
+  static_assert(std::is_standard_layout_v<DAQHeader>, "DAQHeader isn't standard layout; reinterpret_cast and offsetof can't safely be used with it");
+
+  static_assert(sizeof(DAQHeader) == 12);
+  static_assert(offsetof(DAQHeader, timestamp_1) == 4, "timestamp_1 field not at expected offset");
+  static_assert(offsetof(DAQHeader, timestamp_2) == 8, "timestamp_2 field not at expected offset");
+
+} // namespace dunedaq::detdataformats

--- a/include/detdataformats/detail/DAQHeader.hxx
+++ b/include/detdataformats/detail/DAQHeader.hxx
@@ -1,13 +1,17 @@
 
+#include <type_traits>
+#include <bit>
+#include <cstddef>
+
 namespace dunedaq::detdataformats {
 
-  static_assert(std::endian::native == std::endian::little);
+static_assert(std::is_trivially_copyable_v<DAQHeader>, "DAQHeader isn't trivially copyable and can't be safely std::memcpy'd");
+static_assert(std::is_standard_layout_v<DAQHeader>, "DAQHeader isn't standard layout; reinterpret_cast and offsetof can't safely be used with it");
+static_assert(std::endian::native == std::endian::little,
+              "The DAQHeader bitfield layout assumes little-endian architecture");
 
-  static_assert(std::is_trivially_copyable_v<DAQHeader>, "DAQHeader isn't trivially copyable and can't be safely std::memcpy'd");
-  static_assert(std::is_standard_layout_v<DAQHeader>, "DAQHeader isn't standard layout; reinterpret_cast and offsetof can't safely be used with it");
-
-  static_assert(sizeof(DAQHeader) == 12);
-  static_assert(offsetof(DAQHeader, timestamp_1) == 4, "timestamp_1 field not at expected offset");
-  static_assert(offsetof(DAQHeader, timestamp_2) == 8, "timestamp_2 field not at expected offset");
+static_assert(sizeof(DAQHeader) == 12, "DAQHeader struct size different than expected!");
+static_assert(offsetof(DAQHeader, timestamp_1) == 4, "DAQHeader timestamp_1 field not at expected offset");
+static_assert(offsetof(DAQHeader, timestamp_2) == 8, "DAQHeader timestamp_2 field not at expected offset");
 
 } // namespace dunedaq::detdataformats

--- a/include/detdataformats/detail/DAQHeader.hxx
+++ b/include/detdataformats/detail/DAQHeader.hxx
@@ -14,4 +14,13 @@ static_assert(sizeof(DAQHeader) == 12, "DAQHeader struct size different than exp
 static_assert(offsetof(DAQHeader, timestamp_1) == 4, "DAQHeader timestamp_1 field not at expected offset");
 static_assert(offsetof(DAQHeader, timestamp_2) == 8, "DAQHeader timestamp_2 field not at expected offset");
 
+
+inline std::ostream&
+operator<<(std::ostream& o, DAQHeader const& h)
+{
+  return o << "Version:" << unsigned(h.version) << " DetID:" << unsigned(h.det_id) << " CrateID:" << unsigned(h.crate_id)
+           << " SlotID:" << unsigned(h.slot_id) << " LinkID:" << unsigned(h.link_id)
+           << " Timestamp: " << h.get_timestamp() << '\n';
+}
+
 } // namespace dunedaq::detdataformats

--- a/include/detdataformats/detail/DetID.hxx
+++ b/include/detdataformats/detail/DetID.hxx
@@ -1,13 +1,6 @@
 
 namespace dunedaq::detdataformats {
 
-static_assert(DetID::s_det_id_version == 1,
-              "This is intentionally designed to tell the developer to update the static_assert checks (including this "
-              "one) when the version is bumped");
-static_assert(sizeof(DetID) == 4, "DetID struct size different than expected!");
-static_assert(offsetof(DetID, version) == 0, "DetID version field not at expected offset");
-static_assert(offsetof(DetID, subdetector) == 2, "DetID subdetector field not at expected offset");
-
 /**
  * @brief Stream a Subdetector instance in a human-readable form
  * @param o Stream to output to

--- a/include/detdataformats/detail/DetID.hxx
+++ b/include/detdataformats/detail/DetID.hxx
@@ -56,7 +56,7 @@ operator>>(std::istream& is, DetID& det_id)
   return is;
 }
 
-std::string
+inline std::string
 DetID::subdetector_to_string(const Subdetector& type)
 {
   switch (type) {
@@ -91,7 +91,7 @@ DetID::subdetector_to_string(const Subdetector& type)
   }
 }
 
-DetID::Subdetector
+inline DetID::Subdetector
 DetID::string_to_subdetector(const std::string& typestring)
 {
   if (typestring == "DAQ")

--- a/include/detdataformats/detail/HSIFrame.hxx
+++ b/include/detdataformats/detail/HSIFrame.hxx
@@ -1,0 +1,20 @@
+
+#include <cstddef>
+#include <type_traits>
+#include <bit>
+
+namespace dunedaq::detdataformats {
+
+  static_assert(std::endian::native == std::endian::little);
+
+  static_assert(std::is_standard_layout_v<HSIFrame>, "HSIFrame isn't standard layout; reinterpret_cast and offsetof can't safely be used with it");
+
+  static_assert(sizeof(HSIFrame) == 28);
+  static_assert(offsetof(HSIFrame, timestamp_low) == 4, "timestamp_low field not at expected offset");
+  static_assert(offsetof(HSIFrame, timestamp_high) == 8, "timestamp_high field not at expected offset");
+  static_assert(offsetof(HSIFrame, input_low) == 12, "input_low field not at expected offset");
+  static_assert(offsetof(HSIFrame, input_high) == 16, "input_high field not at expected offset");
+  static_assert(offsetof(HSIFrame, trigger) == 20, "trigger field not at expected offset");
+  static_assert(offsetof(HSIFrame, sequence) == 24, "sequence field not at expected offset");
+  
+} // namespace dunedaq::detdataformats

--- a/include/detdataformats/detail/HSIFrame.hxx
+++ b/include/detdataformats/detail/HSIFrame.hxx
@@ -1,20 +1,21 @@
 
-#include <cstddef>
 #include <type_traits>
 #include <bit>
+#include <cstddef>
 
 namespace dunedaq::detdataformats {
 
-  static_assert(std::endian::native == std::endian::little);
+static_assert(std::is_trivially_copyable_v<HSIFrame>, "HSIFrame isn't trivially copyable and can't be safely std::memcpy'd");
+static_assert(std::is_standard_layout_v<HSIFrame>, "HSIFrame isn't standard layout; reinterpret_cast and offsetof can't safely be used with it");
+static_assert(std::endian::native == std::endian::little,
+              "The HSIFrame bitfield layout assumes little-endian architecture");
 
-  static_assert(std::is_standard_layout_v<HSIFrame>, "HSIFrame isn't standard layout; reinterpret_cast and offsetof can't safely be used with it");
+static_assert(sizeof(HSIFrame) == 28, "HSIFrame struct size different than expected!");
+static_assert(offsetof(HSIFrame, timestamp_low) == 4, "HSIFrame timestamp_low field not at expected offset");
+static_assert(offsetof(HSIFrame, timestamp_high) == 8, "HSIFrame timestamp_high field not at expected offset");
+static_assert(offsetof(HSIFrame, input_low) == 12, "HSIFrame input_low field not at expected offset");
+static_assert(offsetof(HSIFrame, input_high) == 16, "HSIFrame input_high field not at expected offset");
+static_assert(offsetof(HSIFrame, trigger) == 20, "HSIFrame trigger field not at expected offset");
+static_assert(offsetof(HSIFrame, sequence) == 24, "HSIFrame sequence field not at expected offset");
 
-  static_assert(sizeof(HSIFrame) == 28);
-  static_assert(offsetof(HSIFrame, timestamp_low) == 4, "timestamp_low field not at expected offset");
-  static_assert(offsetof(HSIFrame, timestamp_high) == 8, "timestamp_high field not at expected offset");
-  static_assert(offsetof(HSIFrame, input_low) == 12, "input_low field not at expected offset");
-  static_assert(offsetof(HSIFrame, input_high) == 16, "input_high field not at expected offset");
-  static_assert(offsetof(HSIFrame, trigger) == 20, "trigger field not at expected offset");
-  static_assert(offsetof(HSIFrame, sequence) == 24, "sequence field not at expected offset");
-  
 } // namespace dunedaq::detdataformats

--- a/pybindsrc/daqethheader.cpp
+++ b/pybindsrc/daqethheader.cpp
@@ -18,6 +18,10 @@ namespace py = pybind11;
 
 namespace dunedaq::detdataformats::python {
 
+  // Quiet the linter about use of unsigned ints below
+  using ui32_t = uint32_t; // NOLINT
+  using ui64_t = uint64_t;  // NOLINT
+
 void
 register_daqethheader(py::module& m)
 {
@@ -34,41 +38,41 @@ register_daqethheader(py::module& m)
     }))
     .def_property(
       "version",
-      [](DAQEthHeader& self) -> uint32_t { return self.version; },
-      [](DAQEthHeader& self, uint32_t version) { self.version = version; })
+      [](DAQEthHeader& self) -> ui32_t { return self.version; },
+      [](DAQEthHeader& self, ui32_t version) { self.version = version; }) // NOLINT(build/unsigned)
     .def_property(
       "det_id",
-      [](DAQEthHeader& self) -> uint32_t { return self.det_id; },
-      [](DAQEthHeader& self, uint32_t det_id) { self.det_id = det_id; })
+      [](DAQEthHeader& self) -> ui32_t { return self.det_id; },
+      [](DAQEthHeader& self, ui32_t det_id) { self.det_id = det_id; })
     .def_property(
       "crate_id",
-      [](DAQEthHeader& self) -> uint32_t { return self.crate_id; },
-      [](DAQEthHeader& self, uint32_t crate_id) { self.crate_id = crate_id; })
+      [](DAQEthHeader& self) -> ui32_t { return self.crate_id; },
+      [](DAQEthHeader& self, ui32_t crate_id) { self.crate_id = crate_id; })
     .def_property(
       "slot_id",
-      [](DAQEthHeader& self) -> uint32_t { return self.slot_id; },
-      [](DAQEthHeader& self, uint32_t slot_id) { self.slot_id = slot_id; })
+      [](DAQEthHeader& self) -> ui32_t { return self.slot_id; },
+      [](DAQEthHeader& self, ui32_t slot_id) { self.slot_id = slot_id; })
     .def_property(
       "stream_id",
-      [](DAQEthHeader& self) -> uint32_t { return self.stream_id; },
-      [](DAQEthHeader& self, uint32_t stream_id) { self.stream_id = stream_id; })
+      [](DAQEthHeader& self) -> ui32_t { return self.stream_id; },
+      [](DAQEthHeader& self, ui32_t stream_id) { self.stream_id = stream_id; })
     .def_property(
       "reserved",
-      [](DAQEthHeader& self) -> uint32_t { return self.reserved; },
-      [](DAQEthHeader& self, uint32_t reserved) { self.reserved = reserved; })
+      [](DAQEthHeader& self) -> ui32_t { return self.reserved; },
+      [](DAQEthHeader& self, ui32_t reserved) { self.reserved = reserved; })
     .def_property(
       "seq_id",
-      [](DAQEthHeader& self) -> uint32_t { return self.seq_id; },
-      [](DAQEthHeader& self, uint32_t seq_id) { self.seq_id = seq_id; })
+      [](DAQEthHeader& self) -> ui32_t { return self.seq_id; },
+      [](DAQEthHeader& self, ui32_t seq_id) { self.seq_id = seq_id; })
     .def_property(
       "block_length",
-      [](DAQEthHeader& self) -> uint32_t { return self.block_length; },
-      [](DAQEthHeader& self, uint32_t block_length) { self.block_length = block_length; })
+      [](DAQEthHeader& self) -> ui32_t { return self.block_length; },
+      [](DAQEthHeader& self, ui32_t block_length) { self.block_length = block_length; })
     .def_property(
       "timestamp",
-      [](DAQEthHeader& self) -> uint64_t { return self.timestamp; },
-      [](DAQEthHeader& self, uint64_t timestamp) { self.timestamp = timestamp; })
-    .def("get_timestamp", &DAQEthHeader::get_timestamp)
+      [](DAQEthHeader& self) -> ui64_t { return self.timestamp; },
+      [](DAQEthHeader& self, ui64_t timestamp) { self.timestamp = timestamp; })
+    //    .def("get_timestamp", &DAQEthHeader::get_timestamp)
     .def_static("sizeof", []() { return sizeof(DAQEthHeader); });
 }
 

--- a/pybindsrc/daqethheader.cpp
+++ b/pybindsrc/daqethheader.cpp
@@ -18,9 +18,8 @@ namespace py = pybind11;
 
 namespace dunedaq::detdataformats::python {
 
-  // Quiet the linter about use of unsigned ints below
-  using ui32_t = uint32_t; // NOLINT
-  using ui64_t = uint64_t;  // NOLINT
+  // Quiet the linter about use of unsigned ints in the file
+  // NOLINTBEGIN(build/unsigned)
 
 void
 register_daqethheader(py::module& m)
@@ -38,42 +37,44 @@ register_daqethheader(py::module& m)
     }))
     .def_property(
       "version",
-      [](DAQEthHeader& self) -> ui32_t { return self.version; },
-      [](DAQEthHeader& self, ui32_t version) { self.version = version; }) // NOLINT(build/unsigned)
+      [](DAQEthHeader& self) -> uint32_t { return self.version; },
+      [](DAQEthHeader& self, uint32_t version) { self.version = version; })
     .def_property(
       "det_id",
-      [](DAQEthHeader& self) -> ui32_t { return self.det_id; },
-      [](DAQEthHeader& self, ui32_t det_id) { self.det_id = det_id; })
+      [](DAQEthHeader& self) -> uint32_t { return self.det_id; },
+      [](DAQEthHeader& self, uint32_t det_id) { self.det_id = det_id; })
     .def_property(
       "crate_id",
-      [](DAQEthHeader& self) -> ui32_t { return self.crate_id; },
-      [](DAQEthHeader& self, ui32_t crate_id) { self.crate_id = crate_id; })
+      [](DAQEthHeader& self) -> uint32_t { return self.crate_id; },
+      [](DAQEthHeader& self, uint32_t crate_id) { self.crate_id = crate_id; })
     .def_property(
       "slot_id",
-      [](DAQEthHeader& self) -> ui32_t { return self.slot_id; },
-      [](DAQEthHeader& self, ui32_t slot_id) { self.slot_id = slot_id; })
+      [](DAQEthHeader& self) -> uint32_t { return self.slot_id; },
+      [](DAQEthHeader& self, uint32_t slot_id) { self.slot_id = slot_id; })
     .def_property(
       "stream_id",
-      [](DAQEthHeader& self) -> ui32_t { return self.stream_id; },
-      [](DAQEthHeader& self, ui32_t stream_id) { self.stream_id = stream_id; })
+      [](DAQEthHeader& self) -> uint32_t { return self.stream_id; },
+      [](DAQEthHeader& self, uint32_t stream_id) { self.stream_id = stream_id; })
     .def_property(
       "reserved",
-      [](DAQEthHeader& self) -> ui32_t { return self.reserved; },
-      [](DAQEthHeader& self, ui32_t reserved) { self.reserved = reserved; })
+      [](DAQEthHeader& self) -> uint32_t { return self.reserved; },
+      [](DAQEthHeader& self, uint32_t reserved) { self.reserved = reserved; })
     .def_property(
       "seq_id",
-      [](DAQEthHeader& self) -> ui32_t { return self.seq_id; },
-      [](DAQEthHeader& self, ui32_t seq_id) { self.seq_id = seq_id; })
+      [](DAQEthHeader& self) -> uint32_t { return self.seq_id; },
+      [](DAQEthHeader& self, uint32_t seq_id) { self.seq_id = seq_id; })
     .def_property(
       "block_length",
-      [](DAQEthHeader& self) -> ui32_t { return self.block_length; },
-      [](DAQEthHeader& self, ui32_t block_length) { self.block_length = block_length; })
+      [](DAQEthHeader& self) -> uint32_t { return self.block_length; },
+      [](DAQEthHeader& self, uint32_t block_length) { self.block_length = block_length; })
     .def_property(
       "timestamp",
-      [](DAQEthHeader& self) -> ui64_t { return self.timestamp; },
-      [](DAQEthHeader& self, ui64_t timestamp) { self.timestamp = timestamp; })
+      [](DAQEthHeader& self) -> uint64_t { return self.timestamp; },
+      [](DAQEthHeader& self, uint64_t timestamp) { self.timestamp = timestamp; })
     .def("get_timestamp", &DAQEthHeader::get_timestamp)
     .def_static("sizeof", []() { return sizeof(DAQEthHeader); });
 }
 
 } // namespace dunedaq::detdataformats::python
+
+// NOLINTEND(build/unsigned)

--- a/pybindsrc/daqethheader.cpp
+++ b/pybindsrc/daqethheader.cpp
@@ -72,7 +72,7 @@ register_daqethheader(py::module& m)
       "timestamp",
       [](DAQEthHeader& self) -> ui64_t { return self.timestamp; },
       [](DAQEthHeader& self, ui64_t timestamp) { self.timestamp = timestamp; })
-    //    .def("get_timestamp", &DAQEthHeader::get_timestamp)
+    .def("get_timestamp", &DAQEthHeader::get_timestamp)
     .def_static("sizeof", []() { return sizeof(DAQEthHeader); });
 }
 

--- a/pybindsrc/daqheader.cpp
+++ b/pybindsrc/daqheader.cpp
@@ -18,47 +18,49 @@ namespace py = pybind11;
 
 namespace dunedaq::detdataformats::python {
 
-  // Quiet the linter about use of unsigned ints below
-  using ui32_t = uint32_t; // NOLINT
+  // Quiet the linter about use of unsigned ints in the file
+  // NOLINTBEGIN(build/unsigned)
 
 void register_daqheader(py::module& m) {
 
   py::class_<DAQHeader>(m, "DAQHeader", py::buffer_protocol())
     .def(py::init<>())
     .def_property("version", 
-      [](DAQHeader& self) -> ui32_t { return self.version; },
-      [](DAQHeader& self, ui32_t version) { self.version = version; }
+      [](DAQHeader& self) -> uint32_t { return self.version; },
+      [](DAQHeader& self, uint32_t version) { self.version = version; }
       )
     .def_property("det_id", 
-      [](DAQHeader& self) -> ui32_t { return self.det_id; },
-      [](DAQHeader& self, ui32_t det_id) { self.det_id = det_id; }
+      [](DAQHeader& self) -> uint32_t { return self.det_id; },
+      [](DAQHeader& self, uint32_t det_id) { self.det_id = det_id; }
       )
     .def_property("crate_id", 
-      [](DAQHeader& self) -> ui32_t { return self.crate_id; },
-      [](DAQHeader& self, ui32_t crate_id) { self.crate_id = crate_id; }
+      [](DAQHeader& self) -> uint32_t { return self.crate_id; },
+      [](DAQHeader& self, uint32_t crate_id) { self.crate_id = crate_id; }
       )
     .def_property("slot_id", 
-      [](DAQHeader& self) -> ui32_t { return self.slot_id; },
-      [](DAQHeader& self, ui32_t slot_id) { self.slot_id = slot_id; }
+      [](DAQHeader& self) -> uint32_t { return self.slot_id; },
+      [](DAQHeader& self, uint32_t slot_id) { self.slot_id = slot_id; }
       )
     .def_property("link_id", 
-      [](DAQHeader& self) -> ui32_t { return self.link_id; },
-      [](DAQHeader& self, ui32_t link_id) { self.link_id = link_id; }
+      [](DAQHeader& self) -> uint32_t { return self.link_id; },
+      [](DAQHeader& self, uint32_t link_id) { self.link_id = link_id; }
       )
     .def_property("timestamp_1", 
-      [](DAQHeader& ) -> ui32_t { 
+      [](DAQHeader& ) -> uint32_t { 
         throw std::runtime_error("Cannot directly read timestamp_1; use get_timestamp() instead"); 
       },
-      [](DAQHeader& self, ui32_t timestamp_1) { self.timestamp_1 = timestamp_1; }
+      [](DAQHeader& self, uint32_t timestamp_1) { self.timestamp_1 = timestamp_1; }
       )
     .def_property("timestamp_2", 
-      [](DAQHeader& ) -> ui32_t { 
+      [](DAQHeader& ) -> uint32_t { 
         throw std::runtime_error("Cannot directly read timestamp_2; use get_timestamp() instead"); 
       },
-      [](DAQHeader& self, ui32_t timestamp_2) { self.timestamp_2 = timestamp_2; }
+      [](DAQHeader& self, uint32_t timestamp_2) { self.timestamp_2 = timestamp_2; }
       )
     .def("get_timestamp", &DAQHeader::get_timestamp)
     ;
 }
 
 }  // namespace dunedaq::detdataformats::python
+
+// NOLINTEND(build/unsigned)

--- a/pybindsrc/daqheader.cpp
+++ b/pybindsrc/daqheader.cpp
@@ -24,6 +24,7 @@ namespace dunedaq::detdataformats::python {
 void register_daqheader(py::module& m) {
 
   py::class_<DAQHeader>(m, "DAQHeader", py::buffer_protocol())
+    .def(py::init<>())
     .def_property("version", 
       [](DAQHeader& self) -> ui32_t { return self.version; },
       [](DAQHeader& self, ui32_t version) { self.version = version; }
@@ -43,6 +44,18 @@ void register_daqheader(py::module& m) {
     .def_property("link_id", 
       [](DAQHeader& self) -> ui32_t { return self.link_id; },
       [](DAQHeader& self, ui32_t link_id) { self.link_id = link_id; }
+      )
+    .def_property("timestamp_1", 
+      [](DAQHeader& self) -> ui32_t { 
+        throw std::runtime_error("Cannot read timestamp_1; use get_timestamp() instead"); 
+      },
+      [](DAQHeader& self, ui32_t timestamp_1) { self.timestamp_1 = timestamp_1; }
+      )
+    .def_property("timestamp_2", 
+      [](DAQHeader& self) -> ui32_t { 
+        throw std::runtime_error("Cannot read timestamp_2; use get_timestamp() instead"); 
+      },
+      [](DAQHeader& self, ui32_t timestamp_2) { self.timestamp_2 = timestamp_2; }
       )
     .def("get_timestamp", &DAQHeader::get_timestamp)
     ;

--- a/pybindsrc/daqheader.cpp
+++ b/pybindsrc/daqheader.cpp
@@ -18,28 +18,31 @@ namespace py = pybind11;
 
 namespace dunedaq::detdataformats::python {
 
+  // Quiet the linter about use of unsigned ints below
+  using ui32_t = uint32_t; // NOLINT
+
 void register_daqheader(py::module& m) {
 
   py::class_<DAQHeader>(m, "DAQHeader", py::buffer_protocol())
     .def_property("version", 
-      [](DAQHeader& self) -> uint32_t { return self.version; }, 
-      [](DAQHeader& self, uint32_t version) { self.version = version; } 
+      [](DAQHeader& self) -> ui32_t { return self.version; },
+      [](DAQHeader& self, ui32_t version) { self.version = version; }
       )
     .def_property("det_id", 
-      [](DAQHeader& self) -> uint32_t { return self.det_id; }, 
-      [](DAQHeader& self, uint32_t det_id) { self.det_id = det_id; } 
+      [](DAQHeader& self) -> ui32_t { return self.det_id; },
+      [](DAQHeader& self, ui32_t det_id) { self.det_id = det_id; }
       )
     .def_property("crate_id", 
-      [](DAQHeader& self) -> uint32_t { return self.crate_id; }, 
-      [](DAQHeader& self, uint32_t crate_id) { self.crate_id = crate_id; } 
+      [](DAQHeader& self) -> ui32_t { return self.crate_id; },
+      [](DAQHeader& self, ui32_t crate_id) { self.crate_id = crate_id; }
       )
     .def_property("slot_id", 
-      [](DAQHeader& self) -> uint32_t { return self.slot_id; }, 
-      [](DAQHeader& self, uint32_t slot_id) { self.slot_id = slot_id; } 
+      [](DAQHeader& self) -> ui32_t { return self.slot_id; },
+      [](DAQHeader& self, ui32_t slot_id) { self.slot_id = slot_id; }
       )
     .def_property("link_id", 
-      [](DAQHeader& self) -> uint32_t { return self.link_id; }, 
-      [](DAQHeader& self, uint32_t link_id) { self.link_id = link_id; } 
+      [](DAQHeader& self) -> ui32_t { return self.link_id; },
+      [](DAQHeader& self, ui32_t link_id) { self.link_id = link_id; }
       )
     .def("get_timestamp", &DAQHeader::get_timestamp)
     ;

--- a/pybindsrc/daqheader.cpp
+++ b/pybindsrc/daqheader.cpp
@@ -46,14 +46,14 @@ void register_daqheader(py::module& m) {
       [](DAQHeader& self, ui32_t link_id) { self.link_id = link_id; }
       )
     .def_property("timestamp_1", 
-      [](DAQHeader& self) -> ui32_t { 
-        throw std::runtime_error("Cannot read timestamp_1; use get_timestamp() instead"); 
+      [](DAQHeader& ) -> ui32_t { 
+        throw std::runtime_error("Cannot directly read timestamp_1; use get_timestamp() instead"); 
       },
       [](DAQHeader& self, ui32_t timestamp_1) { self.timestamp_1 = timestamp_1; }
       )
     .def_property("timestamp_2", 
-      [](DAQHeader& self) -> ui32_t { 
-        throw std::runtime_error("Cannot read timestamp_2; use get_timestamp() instead"); 
+      [](DAQHeader& ) -> ui32_t { 
+        throw std::runtime_error("Cannot directly read timestamp_2; use get_timestamp() instead"); 
       },
       [](DAQHeader& self, ui32_t timestamp_2) { self.timestamp_2 = timestamp_2; }
       )

--- a/pybindsrc/detid.cpp
+++ b/pybindsrc/detid.cpp
@@ -24,11 +24,9 @@ void register_detid(py::module& m) {
       .def(py::init<const DetID::Subdetector&>())
       .def("__repr__", [](const DetID& gid) {
         std::ostringstream oss;
-        oss << "<detdataformats::DetID " << gid.to_string() << ">";
+        oss << "<detdataformats::DetID " << DetID::subdetector_to_string(gid.subdetector) << ">";
         return oss.str();
       })
-      .def("to_string", &DetID::to_string)
-      .def("is_in_valid_state", &DetID::is_in_valid_state)
       .def("subdetector_to_string", &DetID::subdetector_to_string)
       .def("string_to_subdetector", &DetID::string_to_subdetector);
 
@@ -47,8 +45,7 @@ void register_detid(py::module& m) {
       .value("kND_GAr", DetID::Subdetector::kND_GAr)
       .export_values();
 
-  py_detid.def_readwrite("version", &DetID::version)
-      .def_readwrite("subdetector", &DetID::subdetector);
+      py_detid.def_readwrite("subdetector", &DetID::subdetector);
 }
 
 }  // namespace dunedaq::detdataformats::python

--- a/pybindsrc/detid.cpp
+++ b/pybindsrc/detid.cpp
@@ -40,6 +40,8 @@ void register_detid(py::module& m) {
       .value("kVD_MembranePDS", DetID::Subdetector::kVD_MembranePDS)
       .value("kVD_BottomTPC", DetID::Subdetector::kVD_BottomTPC)
       .value("kVD_TopTPC", DetID::Subdetector::kVD_TopTPC)
+      .value("kVD_BernCRT", DetID::Subdetector::kVD_BernCRT)
+      .value("kVD_GrenobleCRT", DetID::Subdetector::kVD_GrenobleCRT)
       .value("kNDLAr_TPC", DetID::Subdetector::kNDLAr_TPC)
       .value("kNDLAr_PDS", DetID::Subdetector::kNDLAr_PDS)
       .value("kND_GAr", DetID::Subdetector::kND_GAr)

--- a/pybindsrc/hsi.cpp
+++ b/pybindsrc/hsi.cpp
@@ -14,6 +14,10 @@ namespace py = pybind11;
 
 namespace dunedaq::detdataformats::python {
 
+  // Quiet the linter about use of unsigned ints below
+  using ui64_t = uint64_t; // NOLINT
+
+  
 void
 register_hsi(py::module& m)
 {
@@ -30,15 +34,15 @@ register_hsi(py::module& m)
       return wfp;
     }))
     .def("get_timestamp", &HSIFrame::get_timestamp)
-    .def_property_readonly("version", [](const HSIFrame& self) -> uint64_t {return self.version;})
-    .def_property_readonly("detector_id", [](const HSIFrame& self) -> uint64_t {return self.detector_id;})
-    .def_property_readonly("crate", [](const HSIFrame& self) -> uint64_t {return self.crate;})
-    .def_property_readonly("slot", [](const HSIFrame& self) -> uint64_t {return self.slot;})
-    .def_property_readonly("link", [](const HSIFrame& self) -> uint64_t {return self.link;})
-    .def_property_readonly("input_low", [](const HSIFrame& self) -> uint64_t {return self.input_low;})
-    .def_property_readonly("input_high", [](const HSIFrame& self) -> uint64_t {return self.input_high;})
-    .def_property_readonly("trigger", [](const HSIFrame& self) -> uint64_t {return self.trigger;})
-    .def_property_readonly("sequence", [](const HSIFrame& self) -> uint64_t {return self.sequence;})
+    .def_property_readonly("version", [](const HSIFrame& self) -> ui64_t {return self.version;})
+    .def_property_readonly("detector_id", [](const HSIFrame& self) -> ui64_t {return self.detector_id;})
+    .def_property_readonly("crate", [](const HSIFrame& self) -> ui64_t {return self.crate;})
+    .def_property_readonly("slot", [](const HSIFrame& self) -> ui64_t {return self.slot;})
+    .def_property_readonly("link", [](const HSIFrame& self) -> ui64_t {return self.link;})
+    .def_property_readonly("input_low", [](const HSIFrame& self) -> ui64_t {return self.input_low;})
+    .def_property_readonly("input_high", [](const HSIFrame& self) -> ui64_t {return self.input_high;})
+    .def_property_readonly("trigger", [](const HSIFrame& self) -> ui64_t {return self.trigger;})
+    .def_property_readonly("sequence", [](const HSIFrame& self) -> ui64_t {return self.sequence;})
     .def_static("sizeof", [](){ return sizeof(HSIFrame); })
   ;
 }

--- a/pybindsrc/hsi.cpp
+++ b/pybindsrc/hsi.cpp
@@ -14,9 +14,8 @@ namespace py = pybind11;
 
 namespace dunedaq::detdataformats::python {
 
-  // Quiet the linter about use of unsigned ints below
-  using ui64_t = uint64_t; // NOLINT
-
+// Quiet the linter about use of unsigned ints in the file
+// NOLINTBEGIN(build/unsigned)
   
 void
 register_hsi(py::module& m)
@@ -34,17 +33,19 @@ register_hsi(py::module& m)
       return wfp;
     }))
     .def("get_timestamp", &HSIFrame::get_timestamp)
-    .def_property_readonly("version", [](const HSIFrame& self) -> ui64_t {return self.version;})
-    .def_property_readonly("detector_id", [](const HSIFrame& self) -> ui64_t {return self.detector_id;})
-    .def_property_readonly("crate", [](const HSIFrame& self) -> ui64_t {return self.crate;})
-    .def_property_readonly("slot", [](const HSIFrame& self) -> ui64_t {return self.slot;})
-    .def_property_readonly("link", [](const HSIFrame& self) -> ui64_t {return self.link;})
-    .def_property_readonly("input_low", [](const HSIFrame& self) -> ui64_t {return self.input_low;})
-    .def_property_readonly("input_high", [](const HSIFrame& self) -> ui64_t {return self.input_high;})
-    .def_property_readonly("trigger", [](const HSIFrame& self) -> ui64_t {return self.trigger;})
-    .def_property_readonly("sequence", [](const HSIFrame& self) -> ui64_t {return self.sequence;})
+    .def_property_readonly("version", [](const HSIFrame& self) -> uint64_t {return self.version;})
+    .def_property_readonly("detector_id", [](const HSIFrame& self) -> uint64_t {return self.detector_id;})
+    .def_property_readonly("crate", [](const HSIFrame& self) -> uint64_t {return self.crate;})
+    .def_property_readonly("slot", [](const HSIFrame& self) -> uint64_t {return self.slot;})
+    .def_property_readonly("link", [](const HSIFrame& self) -> uint64_t {return self.link;})
+    .def_property_readonly("input_low", [](const HSIFrame& self) -> uint64_t {return self.input_low;})
+    .def_property_readonly("input_high", [](const HSIFrame& self) -> uint64_t {return self.input_high;})
+    .def_property_readonly("trigger", [](const HSIFrame& self) -> uint64_t {return self.trigger;})
+    .def_property_readonly("sequence", [](const HSIFrame& self) -> uint64_t {return self.sequence;})
     .def_static("sizeof", [](){ return sizeof(HSIFrame); })
   ;
 }
 
 } // namespace dunedaq::detdataformats::python
+
+// NOLINTEND(build/unsigned)

--- a/pybindsrc/module.cpp
+++ b/pybindsrc/module.cpp
@@ -11,8 +11,6 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
-namespace py = pybind11;
-
 namespace dunedaq::detdataformats::python {
 
 PYBIND11_MODULE(_daq_detdataformats_py, m) {

--- a/pybindsrc/registrators.hpp
+++ b/pybindsrc/registrators.hpp
@@ -20,6 +20,6 @@ namespace dunedaq::detdataformats::python {
   void register_daqheader(pybind11::module&);
   void register_daqethheader(pybind11::module&);
   void register_hsi(pybind11::module&);
-}
+} // namespace dunedaq::detdataformats::python
 
 #endif // DETDATAFORMATS_PYBINDSRC_REGISTRATORS_HPP_

--- a/scripts/DAQEthHeader_binding_test.py
+++ b/scripts/DAQEthHeader_binding_test.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+import sys
+from detdataformats import DAQEthHeader
+
+
+def main() -> int:
+
+    header_size = DAQEthHeader.sizeof()
+    if header_size <= 0:
+        print("DAQEthHeader sizeof test failed")
+        return 1
+    else:
+        print("DAQEthHeader sizeof test passed")
+
+    header = DAQEthHeader(bytes(header_size))
+    print("DAQEthHeader created from raw bytes")
+
+    header.version = 5
+    if header.version != 5:
+        print("DAQEthHeader version property test failed")
+        return 1
+
+    header.det_id = 3
+    if header.det_id != 3:
+        print("DAQEthHeader det_id property test failed")
+        return 1
+
+    header.crate_id = 100
+    if header.crate_id != 100:
+        print("DAQEthHeader crate_id property test failed")
+        return 1
+
+    header.slot_id = 7
+    if header.slot_id != 7:
+        print("DAQEthHeader slot_id property test failed")
+        return 1
+
+    header.stream_id = 42
+    if header.stream_id != 42:
+        print("DAQEthHeader stream_id property test failed")
+        return 1
+
+    header.reserved = 12
+    if header.reserved != 12:
+        print("DAQEthHeader reserved property test failed")
+        return 1
+
+    header.seq_id = 4095
+    if header.seq_id != 4095:
+        print("DAQEthHeader seq_id property test failed")
+        return 1
+
+    header.block_length = 256
+    if header.block_length != 256:
+        print("DAQEthHeader block_length property test failed")
+        return 1
+
+    header.timestamp = 0x1234567890ABCDEF
+    if header.timestamp != 0x1234567890ABCDEF:
+        print("DAQEthHeader timestamp property test failed")
+        return 1
+
+    print("DAQEthHeader basic read/write property tests passed")
+
+    if header.get_timestamp() != 0x1234567890ABCDEF:
+        print("DAQEthHeader get_timestamp() test failed")
+        return 1
+
+    print("DAQEthHeader get_timestamp() test passed")    
+
+    print("\nAll DAQEthHeader Python binding tests passed")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/DAQHeader_binding_test.py
+++ b/scripts/DAQHeader_binding_test.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+import sys
+from detdataformats import DAQHeader
+
+
+def main() -> int:
+
+    header = DAQHeader()
+
+    header.version = 5
+    if header.version != 5:
+        print("DAQHeader version property test failed")
+        return 1
+
+    header.det_id = 3
+    if header.det_id != 3:
+        print("DAQHeader det_id property test failed")
+        return 1
+
+    header.crate_id = 100
+    if header.crate_id != 100:
+        print("DAQHeader crate_id property test failed")
+        return 1
+
+    header.slot_id = 7
+    if header.slot_id != 7:
+        print("DAQHeader slot_id property test failed")
+        return 1
+
+    header.link_id = 15
+    if header.link_id != 15:
+        print("DAQHeader link_id property test failed")
+        return 1
+
+    print("DAQHeader basic read/write property tests passed")
+
+    timestamp_1 = 0x3E8
+    header.timestamp_1 = timestamp_1
+    
+    timestamp_2 = 0x7D0
+    header.timestamp_2 = timestamp_2
+
+    try:
+        _ = header.timestamp_1
+        print("DAQHeader timestamp_1 read should have raised an exception")
+        return 1
+    except Exception:
+        print("DAQHeader timestamp_1 attempted read correctly raised an exception")
+
+    try:
+        _ = header.timestamp_2
+        print("DAQHeader timestamp_2 read should have raised an exception")
+        return 1
+    except Exception:
+        print("DAQHeader timestamp_2 attempted read correctly raised an exception")
+
+    # Test get_timestamp method returns combined timestamp
+    timestamp = header.get_timestamp()
+    expected_timestamp = 0x000007D0000003E8
+    if timestamp != expected_timestamp:
+        print(f"DAQHeader get_timestamp() test failed: got {timestamp}, expected {expected_timestamp}")
+        return 1
+    else:
+        print("DAQHeader get_timestamp() test passed")
+
+    print("\nAll DAQHeader Python binding tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/DetID_binding_test.py
+++ b/scripts/DetID_binding_test.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+import sys
+from detdataformats import DetID
+
+
+def main() -> int:
+
+    detid_default = DetID()
+    if detid_default.subdetector != DetID.Subdetector.kUnknown:
+        print("DetID default subdetector value test failed")
+        return 1
+    else:
+        print("DetID default subdetector value test passed")
+
+    detid = DetID(DetID.Subdetector.kVD_BernCRT)
+
+    if detid.subdetector != DetID.Subdetector.kVD_BernCRT:
+        print("DetID constructor/readwrite field test failed")
+        return 1
+    else:
+        print("DetID constructor/readwrite field test passed")
+
+    subdetector_name = DetID.subdetector_to_string(detid.subdetector)
+    if subdetector_name != "VD_BernCRT":
+        print(f"subdetector_to_string test failed, got: {subdetector_name}")
+        return 1
+    else:
+        print(f"subdetector_to_string test passed, got: {subdetector_name}")
+
+    parsed = DetID.string_to_subdetector("VD_GrenobleCRT")
+    if parsed != DetID.Subdetector.kVD_GrenobleCRT:
+        print("string_to_subdetector test failed")
+        return 1
+    else:
+        print("string_to_subdetector test passed")
+
+    print("\nAll DetID Python binding tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/HSIFrame_binding_test.py
+++ b/scripts/HSIFrame_binding_test.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+
+import sys
+from detdataformats import HSIFrame
+
+
+def main() -> int:
+
+    frame_size = HSIFrame.sizeof()
+    if frame_size <= 0:
+        print("HSIFrame sizeof test failed")
+        return 1
+    else:
+        print("HSIFrame sizeof test passed")
+
+    frame = HSIFrame()
+    print("HSIFrame default constructor test passed")
+
+    # Default-constructed frame has max values for timestamp components
+    default_timestamp = frame.get_timestamp()
+    expected_default_timestamp = 0xFFFFFFFFFFFFFFFF
+    if default_timestamp != expected_default_timestamp:
+        print(f"HSIFrame default get_timestamp() test failed: got {hex(default_timestamp)}, expected {hex(expected_default_timestamp)}")
+        return 1
+    else:
+        print("HSIFrame default get_timestamp() test passed")
+
+    frame_from_bytes = HSIFrame(bytes(frame_size))
+    print("HSIFrame created from raw bytes")
+
+    if frame_from_bytes.version != 0:
+        print("HSIFrame version read from raw bytes test failed")
+        return 1
+
+    if frame_from_bytes.detector_id != 0:
+        print("HSIFrame detector_id read from raw bytes test failed")
+        return 1
+
+    if frame_from_bytes.crate != 0:
+        print("HSIFrame crate read from raw bytes test failed")
+        return 1
+
+    if frame_from_bytes.slot != 0:
+        print("HSIFrame slot read from raw bytes test failed")
+        return 1
+
+    if frame_from_bytes.link != 0:
+        print("HSIFrame link read from raw bytes test failed")
+        return 1
+
+    if frame_from_bytes.input_low != 0:
+        print("HSIFrame input_low read from raw bytes test failed")
+        return 1
+
+    if frame_from_bytes.input_high != 0:
+        print("HSIFrame input_high read from raw bytes test failed")
+        return 1
+
+    if frame_from_bytes.trigger != 0:
+        print("HSIFrame trigger read from raw bytes test failed")
+        return 1
+
+    if frame_from_bytes.sequence != 0:
+        print("HSIFrame sequence read from raw bytes test failed")
+        return 1
+
+    print("HSIFrame read-only property tests passed")
+
+    try:
+        frame_from_bytes.version = 1
+        print("HSIFrame version write should have raised an exception")
+        return 1
+    except Exception:
+        print("HSIFrame version attempted write correctly raised an exception")
+
+    timestamp = frame_from_bytes.get_timestamp()
+    expected_timestamp = 0x0
+    if timestamp != expected_timestamp:
+        print(f"HSIFrame get_timestamp() test failed: got {timestamp}, expected {expected_timestamp}")
+        return 1
+    else:
+        print("HSIFrame zeroed-bytes get_timestamp() test passed")
+
+    print("\nAll HSIFrame Python binding tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/unittest/DAQEthHeader_test.cxx
+++ b/unittest/DAQEthHeader_test.cxx
@@ -1,0 +1,223 @@
+/**
+ * @file DAQEthHeader_test.cxx DAQEthHeader class Unit Tests
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2022.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "detdataformats/DAQEthHeader.hpp"
+
+#define BOOST_TEST_MODULE DAQEthHeader_test  // NOLINT
+
+#include "boost/test/unit_test.hpp"
+
+#include <cstring>
+#include <limits>
+#include <sstream>
+#include <string>
+#include <vector>
+
+using namespace dunedaq::detdataformats;
+
+namespace {
+using word_t = DAQEthHeader::word_t;
+
+DAQEthHeader
+make_header(word_t version,
+            word_t det_id,
+            word_t crate_id,
+            word_t slot_id,
+            word_t stream_id,
+            word_t reserved,
+            word_t seq_id,
+            word_t block_length,
+            word_t timestamp)
+{
+  DAQEthHeader header;
+  header.version = version;
+  header.det_id = det_id;
+  header.crate_id = crate_id;
+  header.slot_id = slot_id;
+  header.stream_id = stream_id;
+  header.reserved = reserved;
+  header.seq_id = seq_id;
+  header.block_length = block_length;
+  header.timestamp = timestamp;
+  return header;
+}
+
+DAQEthHeader
+header_from_stream_output(const std::string& output)
+{
+  std::istringstream iss(output);
+
+  std::string version_token;
+  std::string det_id_token;
+  std::string crate_id_token;
+  std::string slot_id_token;
+  std::string stream_id_token;
+  std::string sequence_label;
+  unsigned int sequence_value{};
+  std::string block_label;
+  std::string block_length_label;
+  unsigned int block_length_value{};
+  std::string timestamp_label;
+  uint64_t timestamp_value{};
+
+  iss >> version_token >> det_id_token >> crate_id_token >> slot_id_token >> stream_id_token >> sequence_label >> sequence_value >> block_label >> block_length_label >> block_length_value >> timestamp_label >> timestamp_value;
+
+  BOOST_REQUIRE_EQUAL(sequence_label, "SequenceID:");
+  BOOST_REQUIRE_EQUAL(block_label, "Block");
+  BOOST_REQUIRE_EQUAL(block_length_label, "length:");
+  BOOST_REQUIRE_EQUAL(timestamp_label, "Timestamp:");
+
+  return make_header(
+    static_cast<word_t>(std::stoull(version_token.substr(std::string("Version:").size()))),
+    static_cast<word_t>(std::stoull(det_id_token.substr(std::string("DetID:").size()))),
+    static_cast<word_t>(std::stoull(crate_id_token.substr(std::string("CrateID:").size()))),
+    static_cast<word_t>(std::stoull(slot_id_token.substr(std::string("SlotID:").size()))),
+    static_cast<word_t>(std::stoull(stream_id_token.substr(std::string("StreamID:").size()))),
+    0,
+    static_cast<word_t>(sequence_value),
+    static_cast<word_t>(block_length_value),
+    static_cast<word_t>(timestamp_value));
+}
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(DAQEthHeader_test)
+
+BOOST_AUTO_TEST_CASE(DefaultConstruction)
+{
+  DAQEthHeader header;
+
+  BOOST_REQUIRE_EQUAL(header.timestamp, std::numeric_limits<word_t>::max());
+  BOOST_REQUIRE_EQUAL(header.get_timestamp(), std::numeric_limits<uint64_t>::max());
+}
+
+BOOST_AUTO_TEST_CASE(TimestampAccess)
+{
+  const DAQEthHeader header = make_header(0, 0, 0, 0, 0, 0, 0, 0, 0x0123456789ABCDEFULL);
+
+  BOOST_REQUIRE_EQUAL(header.get_timestamp(), 0x0123456789ABCDEFULL);
+}
+
+BOOST_AUTO_TEST_CASE(TimestampRoundTripFromGetTimestamp)
+{
+  const std::vector<word_t> values = {
+    0x0000000000000000ULL,
+    0x0000000000000001ULL,
+    0x0123456789ABCDEFULL,
+    0xFEDCBA9876543210ULL,
+    0xFFFFFFFFFFFFFFFFULL
+  };
+
+  for (const auto& value : values) {
+    const DAQEthHeader original = make_header(0, 0, 0, 0, 0, 0, 0, 0, value);
+    const uint64_t timestamp = original.get_timestamp();
+
+    BOOST_REQUIRE_EQUAL(static_cast<word_t>(timestamp), original.timestamp);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(BitfieldUpperBounds)
+{
+  const DAQEthHeader header = make_header(63, 63, 1023, 15, 255, 63, 4095, 4095, 0);
+
+  BOOST_REQUIRE_EQUAL(header.version, 63);
+  BOOST_REQUIRE_EQUAL(header.det_id, 63);
+  BOOST_REQUIRE_EQUAL(header.crate_id, 1023);
+  BOOST_REQUIRE_EQUAL(header.slot_id, 15);
+  BOOST_REQUIRE_EQUAL(header.stream_id, 255);
+  BOOST_REQUIRE_EQUAL(header.reserved, 63);
+  BOOST_REQUIRE_EQUAL(header.seq_id, 4095);
+  BOOST_REQUIRE_EQUAL(header.block_length, 4095);
+}
+
+BOOST_AUTO_TEST_CASE(BitfieldMasking)
+{
+  DAQEthHeader header = make_header(0, 0, 0, 0, 0, 0, 0, 0, 0);
+
+  header.version = 99;         // 99 & 0x3F = 35
+  header.det_id = 127;         // 127 & 0x3F = 63
+  header.crate_id = 2048;      // 2048 & 0x3FF = 0
+  header.slot_id = 31;         // 31 & 0x0F = 15
+  header.stream_id = 511;      // 511 & 0xFF = 255
+  header.reserved = 127;       // 127 & 0x3F = 63
+  header.seq_id = 5000;        // 5000 & 0xFFF = 904
+  header.block_length = 5000;  // 5000 & 0xFFF = 904
+
+  BOOST_REQUIRE_EQUAL(header.version, 35);
+  BOOST_REQUIRE_EQUAL(header.det_id, 63);
+  BOOST_REQUIRE_EQUAL(header.crate_id, 0);
+  BOOST_REQUIRE_EQUAL(header.slot_id, 15);
+  BOOST_REQUIRE_EQUAL(header.stream_id, 255);
+  BOOST_REQUIRE_EQUAL(header.reserved, 63);
+  BOOST_REQUIRE_EQUAL(header.seq_id, 904);
+  BOOST_REQUIRE_EQUAL(header.block_length, 904);
+}
+
+BOOST_AUTO_TEST_CASE(StreamOperatorRoundTrip)
+{
+  const DAQEthHeader original = make_header(
+    7,
+    3,
+    22,
+    4,
+    9,
+    0,
+    1234,
+    88,
+    0x0123456789ABCDEFULL);
+
+  std::ostringstream oss;
+  oss << original;
+  const std::string output = oss.str();
+  const DAQEthHeader recovered = header_from_stream_output(output);
+
+  BOOST_REQUIRE(!output.empty());
+  BOOST_REQUIRE(output.back() == '\n');
+
+  BOOST_REQUIRE_EQUAL(recovered.version, original.version);
+  BOOST_REQUIRE_EQUAL(recovered.det_id, original.det_id);
+  BOOST_REQUIRE_EQUAL(recovered.crate_id, original.crate_id);
+  BOOST_REQUIRE_EQUAL(recovered.slot_id, original.slot_id);
+  BOOST_REQUIRE_EQUAL(recovered.stream_id, original.stream_id);
+  BOOST_REQUIRE_EQUAL(recovered.reserved, original.reserved);
+  BOOST_REQUIRE_EQUAL(recovered.seq_id, original.seq_id);
+  BOOST_REQUIRE_EQUAL(recovered.block_length, original.block_length);
+  BOOST_REQUIRE_EQUAL(recovered.timestamp, original.timestamp);
+}
+
+BOOST_AUTO_TEST_CASE(ByteRoundTrip)
+{
+  const DAQEthHeader original = make_header(
+    13,
+    21,
+    777,
+    10,
+    55,
+    6,
+    2048,
+    1024,
+    0x1122334455667788ULL);
+
+  uint8_t buffer[sizeof(DAQEthHeader)]{};
+  std::memcpy(buffer, &original, sizeof(DAQEthHeader));
+
+  DAQEthHeader recovered;
+  std::memcpy(&recovered, buffer, sizeof(DAQEthHeader));
+
+  BOOST_REQUIRE_EQUAL(recovered.version, original.version);
+  BOOST_REQUIRE_EQUAL(recovered.det_id, original.det_id);
+  BOOST_REQUIRE_EQUAL(recovered.crate_id, original.crate_id);
+  BOOST_REQUIRE_EQUAL(recovered.slot_id, original.slot_id);
+  BOOST_REQUIRE_EQUAL(recovered.stream_id, original.stream_id);
+  BOOST_REQUIRE_EQUAL(recovered.reserved, original.reserved);
+  BOOST_REQUIRE_EQUAL(recovered.seq_id, original.seq_id);
+  BOOST_REQUIRE_EQUAL(recovered.block_length, original.block_length);
+  BOOST_REQUIRE_EQUAL(recovered.timestamp, original.timestamp);
+  BOOST_REQUIRE_EQUAL(recovered.get_timestamp(), original.get_timestamp());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/unittest/DAQEthHeader_test.cxx
+++ b/unittest/DAQEthHeader_test.cxx
@@ -22,6 +22,9 @@
 
 using namespace dunedaq::detdataformats;
 
+// Unit tests for a data formats library can expect to work with a lot of unsigned integers
+// NOLINTBEGIN(build/unsigned)
+
 namespace {
 using word_t = DAQEthHeader::word_t;
 
@@ -85,7 +88,7 @@ header_from_stream_output(const std::string& output)
     static_cast<word_t>(block_length_value),
     static_cast<word_t>(timestamp_value));
 }
-} // namespace
+} // namespace ""
 
 BOOST_AUTO_TEST_SUITE(DAQEthHeader_test)
 
@@ -140,14 +143,14 @@ BOOST_AUTO_TEST_CASE(BitfieldMasking)
 {
   DAQEthHeader header = make_header(0, 0, 0, 0, 0, 0, 0, 0, 0);
 
-  header.version = 99;         // 99 & 0x3F = 35
-  header.det_id = 127;         // 127 & 0x3F = 63
-  header.crate_id = 2048;      // 2048 & 0x3FF = 0
-  header.slot_id = 31;         // 31 & 0x0F = 15
-  header.stream_id = 511;      // 511 & 0xFF = 255
-  header.reserved = 127;       // 127 & 0x3F = 63
-  header.seq_id = 5000;        // 5000 & 0xFFF = 904
-  header.block_length = 5000;  // 5000 & 0xFFF = 904
+  header.version = 99;         // NOLINT 99 & 0x3F = 35
+  header.det_id = 127;         // NOLINT 127 & 0x3F = 63
+  header.crate_id = 2048;      // NOLINT 2048 & 0x3FF = 0
+  header.slot_id = 31;         // NOLINT 31 & 0x0F = 15
+  header.stream_id = 511;      // NOLINT 511 & 0xFF = 255
+  header.reserved = 127;       // NOLINT 127 & 0x3F = 63
+  header.seq_id = 5000;        // NOLINT 5000 & 0xFFF = 904
+  header.block_length = 5000;  // NOLINT 5000 & 0xFFF = 904
 
   BOOST_REQUIRE_EQUAL(header.version, 35);
   BOOST_REQUIRE_EQUAL(header.det_id, 63);
@@ -204,7 +207,7 @@ BOOST_AUTO_TEST_CASE(ByteRoundTrip)
     1024,
     0x1122334455667788ULL);
 
-  uint8_t buffer[sizeof(DAQEthHeader)]{};
+  uint8_t buffer[sizeof(DAQEthHeader)]; // NOLINT(modernize-avoid-c-arrays)
   std::memcpy(buffer, &original, sizeof(DAQEthHeader));
 
   DAQEthHeader recovered;
@@ -223,3 +226,5 @@ BOOST_AUTO_TEST_CASE(ByteRoundTrip)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+
+// NOLINTEND(build/unsigned)

--- a/unittest/DAQEthHeader_test.cxx
+++ b/unittest/DAQEthHeader_test.cxx
@@ -18,6 +18,8 @@
 #include <string>
 #include <vector>
 
+#pragma GCC diagnostic ignored "-Woverflow" // intentional overflows are performed as part of testing
+
 using namespace dunedaq::detdataformats;
 
 namespace {

--- a/unittest/DAQHeader_test.cxx
+++ b/unittest/DAQHeader_test.cxx
@@ -17,11 +17,15 @@
 #include <sstream>
 #include <string>
 #include <tuple>
+#include <utility>
 #include <vector>
 
 #pragma GCC diagnostic ignored "-Woverflow" // intentional overflows are performed as part of testing
 
 using namespace dunedaq::detdataformats;
+
+// Unit tests for a data formats library can expect to work with a lot of unsigned integers
+// NOLINTBEGIN(build/unsigned)
 
 namespace {
 using word_t = DAQHeader::word_t;
@@ -81,7 +85,7 @@ header_from_stream_output(const std::string& output)
     timestamp_1,
     timestamp_2);
 }
-}
+} // namespace ""
 
 BOOST_AUTO_TEST_SUITE(DAQHeader_test)
 
@@ -136,11 +140,11 @@ BOOST_AUTO_TEST_CASE(BitfieldMasking)
 {
   DAQHeader header = make_header(0, 0, 0, 0, 0, 0, 0);
 
-  header.version = 99;     // 99 & 0x3F = 35
-  header.det_id = 127;     // 127 & 0x3F = 63
-  header.crate_id = 2048;  // 2048 & 0x3FF = 0
-  header.slot_id = 31;     // 31 & 0x0F = 15
-  header.link_id = 65;     // 65 & 0x3F = 1
+  header.version = 99;     // NOLINT 99 & 0x3F = 35
+  header.det_id = 127;     // NOLINT 127 & 0x3F = 63
+  header.crate_id = 2048;  // NOLINT 2048 & 0x3FF = 0
+  header.slot_id = 31;     // NOLINT 31 & 0x0F = 15
+  header.link_id = 65;     // NOLINT 65 & 0x3F = 1
 
   BOOST_REQUIRE_EQUAL(header.version, 35);
   BOOST_REQUIRE_EQUAL(header.det_id, 63);
@@ -174,7 +178,7 @@ BOOST_AUTO_TEST_CASE(ByteRoundTrip)
 {
   const DAQHeader original = make_header(13, 21, 777, 10, 55, 0x11111111, 0x22222222);
 
-  uint8_t buffer[sizeof(DAQHeader)]{};
+  uint8_t buffer[sizeof(DAQHeader)]; // NOLINT(modernize-avoid-c-arrays)
   std::memcpy(buffer, &original, sizeof(DAQHeader));
 
   DAQHeader recovered;
@@ -191,3 +195,5 @@ BOOST_AUTO_TEST_CASE(ByteRoundTrip)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+
+// NOLINTEND(build/unsigned)

--- a/unittest/DAQHeader_test.cxx
+++ b/unittest/DAQHeader_test.cxx
@@ -1,0 +1,191 @@
+/**
+ * @file DAQHeader_test.cxx DAQHeader class Unit Tests
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2022.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "detdataformats/DAQHeader.hpp"
+
+#define BOOST_TEST_MODULE DAQHeader_test  // NOLINT
+
+#include "boost/test/unit_test.hpp"
+
+#include <cstring>
+#include <limits>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <vector>
+
+using namespace dunedaq::detdataformats;
+
+namespace {
+using word_t = DAQHeader::word_t;
+
+DAQHeader
+make_header(word_t version,
+            word_t det_id,
+            word_t crate_id,
+            word_t slot_id,
+            word_t link_id,
+            word_t timestamp_1,
+            word_t timestamp_2)
+{
+  DAQHeader header;
+  header.version = version;
+  header.det_id = det_id;
+  header.crate_id = crate_id;
+  header.slot_id = slot_id;
+  header.link_id = link_id;
+  header.timestamp_1 = timestamp_1;
+  header.timestamp_2 = timestamp_2;
+  return header;
+}
+
+std::pair<word_t, word_t>
+split_timestamp(uint64_t timestamp)
+{
+  return {
+    static_cast<word_t>(timestamp),
+    static_cast<word_t>(timestamp >> 32)
+  };
+}
+
+DAQHeader
+header_from_stream_output(const std::string& output)
+{
+  std::istringstream iss(output);
+
+  std::string version_token;
+  std::string det_id_token;
+  std::string crate_id_token;
+  std::string slot_id_token;
+  std::string link_id_token;
+  std::string timestamp_label;
+  uint64_t timestamp_value{};
+
+  iss >> version_token >> det_id_token >> crate_id_token >> slot_id_token >> link_id_token >> timestamp_label >> timestamp_value;
+
+  const auto [timestamp_1, timestamp_2] = split_timestamp(timestamp_value);
+
+  return make_header(
+    static_cast<word_t>(std::stoul(version_token.substr(std::string("Version:").size()))),
+    static_cast<word_t>(std::stoul(det_id_token.substr(std::string("DetID:").size()))),
+    static_cast<word_t>(std::stoul(crate_id_token.substr(std::string("CrateID:").size()))),
+    static_cast<word_t>(std::stoul(slot_id_token.substr(std::string("SlotID:").size()))),
+    static_cast<word_t>(std::stoul(link_id_token.substr(std::string("LinkID:").size()))),
+    timestamp_1,
+    timestamp_2);
+}
+}
+
+BOOST_AUTO_TEST_SUITE(DAQHeader_test)
+
+BOOST_AUTO_TEST_CASE(DefaultConstruction)
+{
+  DAQHeader header;
+
+  BOOST_REQUIRE_EQUAL(header.timestamp_1, std::numeric_limits<word_t>::max());
+  BOOST_REQUIRE_EQUAL(header.timestamp_2, std::numeric_limits<word_t>::max());
+  BOOST_REQUIRE_EQUAL(header.get_timestamp(), std::numeric_limits<uint64_t>::max());
+}
+
+BOOST_AUTO_TEST_CASE(TimestampAssembly)
+{
+  DAQHeader header = make_header(0, 0, 0, 0, 0, 0x89ABCDEF, 0x01234567);
+
+  BOOST_REQUIRE_EQUAL(header.get_timestamp(), 0x0123456789ABCDEFULL);
+}
+
+BOOST_AUTO_TEST_CASE(TimestampRoundTripFromGetTimestamp)
+{
+  const std::vector<std::pair<word_t, word_t>> values = {
+    { 0x00000000u, 0x00000000u },
+    { 0xFFFFFFFFu, 0x00000000u },
+    { 0x00000000u, 0xFFFFFFFFu },
+    { 0x01234567u, 0x89ABCDEFu },
+    { 0xFFFFFFFFu, 0xFFFFFFFFu }
+  };
+
+  for (const auto& value : values) {
+    const DAQHeader original = make_header(0, 0, 0, 0, 0, value.first, value.second);
+    const uint64_t timestamp = original.get_timestamp();
+    const auto [timestamp_1, timestamp_2] = split_timestamp(timestamp);
+
+    BOOST_REQUIRE_EQUAL(timestamp_1, original.timestamp_1);
+    BOOST_REQUIRE_EQUAL(timestamp_2, original.timestamp_2);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(BitfieldUpperBounds)
+{
+  DAQHeader header = make_header(63, 63, 1023, 15, 63, 0, 0);
+
+  BOOST_REQUIRE_EQUAL(header.version, 63);
+  BOOST_REQUIRE_EQUAL(header.det_id, 63);
+  BOOST_REQUIRE_EQUAL(header.crate_id, 1023);
+  BOOST_REQUIRE_EQUAL(header.slot_id, 15);
+  BOOST_REQUIRE_EQUAL(header.link_id, 63);
+}
+
+BOOST_AUTO_TEST_CASE(BitfieldMasking)
+{
+  DAQHeader header = make_header(0, 0, 0, 0, 0, 0, 0);
+
+  header.version = 99;     // 99 & 0x3F = 35
+  header.det_id = 127;     // 127 & 0x3F = 63
+  header.crate_id = 2048;  // 2048 & 0x3FF = 0
+  header.slot_id = 31;     // 31 & 0x0F = 15
+  header.link_id = 65;     // 65 & 0x3F = 1
+
+  BOOST_REQUIRE_EQUAL(header.version, 35);
+  BOOST_REQUIRE_EQUAL(header.det_id, 63);
+  BOOST_REQUIRE_EQUAL(header.crate_id, 0);
+  BOOST_REQUIRE_EQUAL(header.slot_id, 15);
+  BOOST_REQUIRE_EQUAL(header.link_id, 1);
+}
+
+BOOST_AUTO_TEST_CASE(StreamOperatorRoundTrip)
+{
+  const DAQHeader original = make_header(7, 3, 22, 4, 9, 0x01234567, 0x89ABCDEF);
+
+  std::ostringstream oss;
+  oss << original;
+  const std::string output = oss.str();
+  const DAQHeader recovered = header_from_stream_output(output);
+
+  BOOST_REQUIRE(!output.empty());
+  BOOST_REQUIRE(output.back() == '\n');
+
+  BOOST_REQUIRE_EQUAL(recovered.version, original.version);
+  BOOST_REQUIRE_EQUAL(recovered.det_id, original.det_id);
+  BOOST_REQUIRE_EQUAL(recovered.crate_id, original.crate_id);
+  BOOST_REQUIRE_EQUAL(recovered.slot_id, original.slot_id);
+  BOOST_REQUIRE_EQUAL(recovered.link_id, original.link_id);
+  BOOST_REQUIRE_EQUAL(recovered.timestamp_1, original.timestamp_1);
+  BOOST_REQUIRE_EQUAL(recovered.timestamp_2, original.timestamp_2);
+}
+
+BOOST_AUTO_TEST_CASE(ByteRoundTrip)
+{
+  const DAQHeader original = make_header(13, 21, 777, 10, 55, 0x11111111, 0x22222222);
+
+  uint8_t buffer[sizeof(DAQHeader)]{};
+  std::memcpy(buffer, &original, sizeof(DAQHeader));
+
+  DAQHeader recovered;
+  std::memcpy(&recovered, buffer, sizeof(DAQHeader));
+
+  BOOST_REQUIRE_EQUAL(recovered.version, original.version);
+  BOOST_REQUIRE_EQUAL(recovered.det_id, original.det_id);
+  BOOST_REQUIRE_EQUAL(recovered.crate_id, original.crate_id);
+  BOOST_REQUIRE_EQUAL(recovered.slot_id, original.slot_id);
+  BOOST_REQUIRE_EQUAL(recovered.link_id, original.link_id);
+  BOOST_REQUIRE_EQUAL(recovered.timestamp_1, original.timestamp_1);
+  BOOST_REQUIRE_EQUAL(recovered.timestamp_2, original.timestamp_2);
+  BOOST_REQUIRE_EQUAL(recovered.get_timestamp(), original.get_timestamp());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/unittest/DAQHeader_test.cxx
+++ b/unittest/DAQHeader_test.cxx
@@ -19,6 +19,8 @@
 #include <tuple>
 #include <vector>
 
+#pragma GCC diagnostic ignored "-Woverflow" // intentional overflows are performed as part of testing
+
 using namespace dunedaq::detdataformats;
 
 namespace {

--- a/unittest/DetID_test.cxx
+++ b/unittest/DetID_test.cxx
@@ -25,8 +25,6 @@ BOOST_AUTO_TEST_CASE(Comprehensive)
 
   DetID detid = { DetID::Subdetector::kND_GAr };
 
-  BOOST_REQUIRE(detid.is_in_valid_state());
-
   std::ostringstream ostr;
   ostr << detid;
   std::string output = ostr.str();
@@ -39,11 +37,10 @@ BOOST_AUTO_TEST_CASE(Comprehensive)
   std::istringstream iss(ostr.str());
   DetID detid_from_stream;
   iss >> detid_from_stream;
-  BOOST_REQUIRE_EQUAL(detid_from_stream.version, detid.version);
   BOOST_REQUIRE_EQUAL(detid_from_stream.subdetector, detid.subdetector);
 
   DetID detid_default;
-  BOOST_REQUIRE(!detid_default.is_in_valid_state());
+  BOOST_REQUIRE(detid_default.subdetector == DetID::Subdetector::kUnknown);
 
 }
 

--- a/unittest/DetID_test.cxx
+++ b/unittest/DetID_test.cxx
@@ -18,13 +18,6 @@
 
 using namespace dunedaq::detdataformats;
 
-namespace {
-  inline DetID from_string(const std::string& str)
-  {
-    return DetID(DetID::string_to_subdetector(str));
-  }
-}
-
 BOOST_AUTO_TEST_SUITE(DetID_test)
 
 BOOST_AUTO_TEST_CASE(DefaultConstruction)

--- a/unittest/DetID_test.cxx
+++ b/unittest/DetID_test.cxx
@@ -18,30 +18,203 @@
 
 using namespace dunedaq::detdataformats;
 
+namespace {
+  inline DetID from_string(const std::string& str)
+  {
+    return DetID(DetID::string_to_subdetector(str));
+  }
+}
+
 BOOST_AUTO_TEST_SUITE(DetID_test)
 
-BOOST_AUTO_TEST_CASE(Comprehensive)
+BOOST_AUTO_TEST_CASE(DefaultConstruction)
 {
+  DetID detid;
+  BOOST_REQUIRE_EQUAL(detid.subdetector, DetID::Subdetector::kUnknown);
+}
 
-  DetID detid = { DetID::Subdetector::kND_GAr };
+BOOST_AUTO_TEST_CASE(ExplicitConstruction)
+{
+  DetID detid(DetID::Subdetector::kND_GAr);
+  BOOST_REQUIRE_EQUAL(detid.subdetector, DetID::Subdetector::kND_GAr);
+}
 
+BOOST_AUTO_TEST_CASE(ImplicitConstruction)
+{
+  // Test implicit conversion from Subdetector to DetID
+  DetID detid = DetID::Subdetector::kHD_TPC;
+  BOOST_REQUIRE_EQUAL(detid.subdetector, DetID::Subdetector::kHD_TPC);
+}
+
+BOOST_AUTO_TEST_CASE(AllSubdetectorValues)
+{
+  // Test all defined subdetector enum values
+  const std::vector<DetID::Subdetector> all_subdetectors = {
+    DetID::Subdetector::kUnknown,
+    DetID::Subdetector::kDAQ,
+    DetID::Subdetector::kHD_PDS,
+    DetID::Subdetector::kHD_TPC,
+    DetID::Subdetector::kHD_CRT,
+    DetID::Subdetector::kVD_CathodePDS,
+    DetID::Subdetector::kVD_MembranePDS,
+    DetID::Subdetector::kVD_BottomTPC,
+    DetID::Subdetector::kVD_TopTPC,
+    DetID::Subdetector::kVD_BernCRT,
+    DetID::Subdetector::kVD_GrenobleCRT,
+    DetID::Subdetector::kNDLAr_TPC,
+    DetID::Subdetector::kNDLAr_PDS,
+    DetID::Subdetector::kND_GAr
+  };
+
+  for (const auto& subdet : all_subdetectors) {
+    DetID detid(subdet);
+    BOOST_REQUIRE_EQUAL(detid.subdetector, subdet);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(SubdetectorToString)
+{
+  BOOST_REQUIRE_EQUAL(DetID::subdetector_to_string(DetID::Subdetector::kUnknown), "Unknown");
+  BOOST_REQUIRE_EQUAL(DetID::subdetector_to_string(DetID::Subdetector::kDAQ), "DAQ");
+  BOOST_REQUIRE_EQUAL(DetID::subdetector_to_string(DetID::Subdetector::kHD_PDS), "HD_PDS");
+  BOOST_REQUIRE_EQUAL(DetID::subdetector_to_string(DetID::Subdetector::kHD_TPC), "HD_TPC");
+  BOOST_REQUIRE_EQUAL(DetID::subdetector_to_string(DetID::Subdetector::kHD_CRT), "HD_CRT");
+  BOOST_REQUIRE_EQUAL(DetID::subdetector_to_string(DetID::Subdetector::kVD_CathodePDS), "VD_CathodePDS");
+  BOOST_REQUIRE_EQUAL(DetID::subdetector_to_string(DetID::Subdetector::kVD_MembranePDS), "VD_MembranePDS");
+  BOOST_REQUIRE_EQUAL(DetID::subdetector_to_string(DetID::Subdetector::kVD_BottomTPC), "VD_BottomTPC");
+  BOOST_REQUIRE_EQUAL(DetID::subdetector_to_string(DetID::Subdetector::kVD_TopTPC), "VD_TopTPC");
+  BOOST_REQUIRE_EQUAL(DetID::subdetector_to_string(DetID::Subdetector::kVD_BernCRT), "VD_BernCRT");
+  BOOST_REQUIRE_EQUAL(DetID::subdetector_to_string(DetID::Subdetector::kVD_GrenobleCRT), "VD_GrenobleCRT");
+  BOOST_REQUIRE_EQUAL(DetID::subdetector_to_string(DetID::Subdetector::kNDLAr_TPC), "NDLAr_TPC");
+  BOOST_REQUIRE_EQUAL(DetID::subdetector_to_string(DetID::Subdetector::kNDLAr_PDS), "NDLAr_PDS");
+  BOOST_REQUIRE_EQUAL(DetID::subdetector_to_string(DetID::Subdetector::kND_GAr), "ND_GAr");
+}
+
+BOOST_AUTO_TEST_CASE(StringToSubdetector)
+{
+  BOOST_REQUIRE_EQUAL(DetID::string_to_subdetector("Unknown"), DetID::Subdetector::kUnknown);
+  BOOST_REQUIRE_EQUAL(DetID::string_to_subdetector("DAQ"), DetID::Subdetector::kDAQ);
+  BOOST_REQUIRE_EQUAL(DetID::string_to_subdetector("HD_PDS"), DetID::Subdetector::kHD_PDS);
+  BOOST_REQUIRE_EQUAL(DetID::string_to_subdetector("HD_TPC"), DetID::Subdetector::kHD_TPC);
+  BOOST_REQUIRE_EQUAL(DetID::string_to_subdetector("HD_CRT"), DetID::Subdetector::kHD_CRT);
+  BOOST_REQUIRE_EQUAL(DetID::string_to_subdetector("VD_CathodePDS"), DetID::Subdetector::kVD_CathodePDS);
+  BOOST_REQUIRE_EQUAL(DetID::string_to_subdetector("VD_MembranePDS"), DetID::Subdetector::kVD_MembranePDS);
+  BOOST_REQUIRE_EQUAL(DetID::string_to_subdetector("VD_BottomTPC"), DetID::Subdetector::kVD_BottomTPC);
+  BOOST_REQUIRE_EQUAL(DetID::string_to_subdetector("VD_TopTPC"), DetID::Subdetector::kVD_TopTPC);
+  BOOST_REQUIRE_EQUAL(DetID::string_to_subdetector("VD_BernCRT"), DetID::Subdetector::kVD_BernCRT);
+  BOOST_REQUIRE_EQUAL(DetID::string_to_subdetector("VD_GrenobleCRT"), DetID::Subdetector::kVD_GrenobleCRT);
+  BOOST_REQUIRE_EQUAL(DetID::string_to_subdetector("NDLAr_TPC"), DetID::Subdetector::kNDLAr_TPC);
+  BOOST_REQUIRE_EQUAL(DetID::string_to_subdetector("NDLAr_PDS"), DetID::Subdetector::kNDLAr_PDS);
+  BOOST_REQUIRE_EQUAL(DetID::string_to_subdetector("ND_GAr"), DetID::Subdetector::kND_GAr);
+}
+
+BOOST_AUTO_TEST_CASE(StringToSubdetectorInvalid)
+{
+  // Invalid strings should fall back to kUnknown
+  BOOST_REQUIRE_EQUAL(DetID::string_to_subdetector("InvalidName"), DetID::Subdetector::kUnknown);
+  BOOST_REQUIRE_EQUAL(DetID::string_to_subdetector(""), DetID::Subdetector::kUnknown);
+  BOOST_REQUIRE_EQUAL(DetID::string_to_subdetector("hd_tpc"), DetID::Subdetector::kUnknown);  // case sensitive
+}
+
+BOOST_AUTO_TEST_CASE(ConversionRoundTrip)
+{
+  // Test that conversion to/from string is reversible for all values
+  const std::vector<DetID::Subdetector> all_subdetectors = {
+    DetID::Subdetector::kUnknown,
+    DetID::Subdetector::kDAQ,
+    DetID::Subdetector::kHD_PDS,
+    DetID::Subdetector::kHD_TPC,
+    DetID::Subdetector::kHD_CRT,
+    DetID::Subdetector::kVD_CathodePDS,
+    DetID::Subdetector::kVD_MembranePDS,
+    DetID::Subdetector::kVD_BottomTPC,
+    DetID::Subdetector::kVD_TopTPC,
+    DetID::Subdetector::kVD_BernCRT,
+    DetID::Subdetector::kVD_GrenobleCRT,
+    DetID::Subdetector::kNDLAr_TPC,
+    DetID::Subdetector::kNDLAr_PDS,
+    DetID::Subdetector::kND_GAr
+  };
+
+  for (const auto& subdet : all_subdetectors) {
+    std::string str = DetID::subdetector_to_string(subdet);
+    DetID::Subdetector recovered = DetID::string_to_subdetector(str);
+    BOOST_REQUIRE_EQUAL(recovered, subdet);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(StreamOperatorOutput)
+{
+  DetID detid(DetID::Subdetector::kND_GAr);
   std::ostringstream ostr;
   ostr << detid;
   std::string output = ostr.str();
-  BOOST_TEST_MESSAGE("Stream operator: " << output);
+  BOOST_TEST_MESSAGE("Stream output: " << output);
 
   BOOST_REQUIRE(!output.empty());
-  auto pos = output.find("subdetector: ND_GAr");
-  BOOST_REQUIRE(pos != std::string::npos);
+  BOOST_REQUIRE(output.find("subdetector: ND_GAr") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(StreamOperatorRoundTrip)
+{
+  DetID detid(DetID::Subdetector::kHD_TPC);
+  std::ostringstream ostr;
+  ostr << detid;
 
   std::istringstream iss(ostr.str());
   DetID detid_from_stream;
   iss >> detid_from_stream;
+  
   BOOST_REQUIRE_EQUAL(detid_from_stream.subdetector, detid.subdetector);
+}
 
-  DetID detid_default;
-  BOOST_REQUIRE(detid_default.subdetector == DetID::Subdetector::kUnknown);
+BOOST_AUTO_TEST_CASE(StreamOperatorRoundTripAll)
+{
+  // Test round-trip for all subdetector values:
+  // DetID -> (<<) -> string -> (>>) -> DetID', verify equal
+  const std::vector<DetID::Subdetector> all_subdetectors = {
+    DetID::Subdetector::kUnknown,
+    DetID::Subdetector::kDAQ,
+    DetID::Subdetector::kHD_PDS,
+    DetID::Subdetector::kHD_TPC,
+    DetID::Subdetector::kHD_CRT,
+    DetID::Subdetector::kVD_CathodePDS,
+    DetID::Subdetector::kVD_MembranePDS,
+    DetID::Subdetector::kVD_BottomTPC,
+    DetID::Subdetector::kVD_TopTPC,
+    DetID::Subdetector::kVD_BernCRT,
+    DetID::Subdetector::kVD_GrenobleCRT,
+    DetID::Subdetector::kNDLAr_TPC,
+    DetID::Subdetector::kNDLAr_PDS,
+    DetID::Subdetector::kND_GAr
+  };
 
+  for (const auto& subdet : all_subdetectors) {
+    DetID original(subdet);
+    
+    // Serialize to string using <<
+    std::ostringstream oss;
+    oss << original;
+    std::string serialized = oss.str();
+    
+    // Deserialize from string using >>
+    std::istringstream iss(serialized);
+    DetID recovered;
+    iss >> recovered;
+    
+    // Verify they're equal
+    BOOST_REQUIRE_EQUAL(recovered.subdetector, original.subdetector);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(SubdetectorEnumOperator)
+{
+  // Test stream operator on Subdetector enum directly
+  DetID::Subdetector subdet = DetID::Subdetector::kHD_TPC;
+  std::ostringstream ostr;
+  ostr << subdet;
+  std::string output = ostr.str();
+  BOOST_REQUIRE_EQUAL(output, "HD_TPC");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittest/DetID_test.cxx
+++ b/unittest/DetID_test.cxx
@@ -9,7 +9,7 @@
 
 #include "detdataformats/DetID.hpp"
 
-#define BOOST_TEST_MODULE DetID_test 
+#define BOOST_TEST_MODULE DetID_test  // NOLINT
 
 #include "boost/test/unit_test.hpp"
 

--- a/unittest/HSIFrame_test.cxx
+++ b/unittest/HSIFrame_test.cxx
@@ -1,0 +1,277 @@
+/**
+ * @file HSIFrame_test.cxx HSIFrame class Unit Tests
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2022.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "detdataformats/HSIFrame.hpp"
+
+#define BOOST_TEST_MODULE HSIFrame_test  // NOLINT
+
+#include "boost/test/unit_test.hpp"
+
+#include <cstring>
+#include <limits>
+
+using namespace dunedaq::detdataformats;
+
+namespace {
+  // Helper to create HSIFrame from individual components
+  HSIFrame make_frame(uint32_t version, uint32_t detector_id, uint32_t crate, 
+                      uint32_t slot, uint32_t link,
+                      uint64_t timestamp, uint32_t input_low, uint32_t input_high,
+                      uint32_t trigger, uint32_t sequence)
+  {
+    HSIFrame frame;
+    frame.version = version;
+    frame.detector_id = detector_id;
+    frame.crate = crate;
+    frame.slot = slot;
+    frame.link = link;
+    frame.set_timestamp(timestamp);
+    frame.input_low = input_low;
+    frame.input_high = input_high;
+    frame.trigger = trigger;
+    frame.sequence = sequence;
+    return frame;
+  }
+}
+
+BOOST_AUTO_TEST_SUITE(HSIFrame_test)
+
+BOOST_AUTO_TEST_CASE(DefaultConstruction)
+{
+  HSIFrame frame;
+  
+    // Note: bitfield members are uninitialized by default, so we don't test them here
+  BOOST_REQUIRE_EQUAL(frame.get_timestamp(), std::numeric_limits<uint64_t>::max());
+  BOOST_REQUIRE_EQUAL(frame.input_low, std::numeric_limits<uint32_t>::max());
+  BOOST_REQUIRE_EQUAL(frame.input_high, std::numeric_limits<uint32_t>::max());
+  BOOST_REQUIRE_EQUAL(frame.trigger, std::numeric_limits<uint32_t>::max());
+  BOOST_REQUIRE_EQUAL(frame.sequence, std::numeric_limits<uint32_t>::max());
+}
+
+BOOST_AUTO_TEST_CASE(GetTimestamp)
+{
+  HSIFrame frame;
+  
+  uint64_t ts = frame.get_timestamp();
+  BOOST_REQUIRE_EQUAL(ts, std::numeric_limits<uint64_t>::max());
+}
+
+BOOST_AUTO_TEST_CASE(SetTimestampMax)
+{
+  HSIFrame frame;
+  
+  uint64_t max_ts = std::numeric_limits<uint64_t>::max();
+  frame.set_timestamp(max_ts);
+  BOOST_REQUIRE_EQUAL(frame.get_timestamp(), max_ts);
+  BOOST_REQUIRE_EQUAL(frame.timestamp_low, std::numeric_limits<uint32_t>::max());
+  BOOST_REQUIRE_EQUAL(frame.timestamp_high, std::numeric_limits<uint32_t>::max());
+}
+
+BOOST_AUTO_TEST_CASE(SetTimestampSplit)
+{
+  HSIFrame frame;
+  
+  // Test a 64-bit value that crosses the 32-bit boundary
+  uint64_t ts = 0x0123456789ABCDEF;
+  frame.set_timestamp(ts);
+  
+  BOOST_REQUIRE_EQUAL(frame.get_timestamp(), ts);
+  BOOST_REQUIRE_EQUAL(frame.timestamp_low, 0x89ABCDEF);      // lower 32 bits
+  BOOST_REQUIRE_EQUAL(frame.timestamp_high, 0x01234567);     // upper 32 bits
+}
+
+BOOST_AUTO_TEST_CASE(TimestampRoundTrip)
+{
+  // Test a range of timestamp values
+  const std::vector<uint64_t> test_timestamps = {
+    0,
+    1,
+    0xFF,
+    0xFFFFFFFF,  // max 32-bit
+    0x100000000,  // just above 32-bit
+    0x123456789ABCDEF0,
+    std::numeric_limits<uint64_t>::max()
+  };
+
+  for (const auto& ts : test_timestamps) {
+    HSIFrame frame;
+    frame.set_timestamp(ts);
+    BOOST_REQUIRE_EQUAL(frame.get_timestamp(), ts);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(BitfieldMembers)
+{
+  HSIFrame frame;
+  
+  frame.version = 5;
+  frame.detector_id = 3;
+  frame.crate = 7;
+  frame.slot = 2;
+  frame.link = 42;
+  
+  BOOST_REQUIRE_EQUAL(frame.version, 5);
+  BOOST_REQUIRE_EQUAL(frame.detector_id, 3);
+  BOOST_REQUIRE_EQUAL(frame.crate, 7);
+  BOOST_REQUIRE_EQUAL(frame.slot, 2);
+  BOOST_REQUIRE_EQUAL(frame.link, 42);
+}
+
+BOOST_AUTO_TEST_CASE(BitfieldMask)
+{
+  HSIFrame frame;
+  
+  // version is 6 bits: max value 63
+  frame.version = 63;
+  BOOST_REQUIRE_EQUAL(frame.version, 63);
+  
+  // detector_id is 6 bits: max value 63
+  frame.detector_id = 63;
+  BOOST_REQUIRE_EQUAL(frame.detector_id, 63);
+  
+  // crate is 10 bits: max value 1023
+  frame.crate = 1023;
+  BOOST_REQUIRE_EQUAL(frame.crate, 1023);
+  
+  // slot is 4 bits: max value 15
+  frame.slot = 15;
+  BOOST_REQUIRE_EQUAL(frame.slot, 15);
+  
+  // link is 6 bits: max value 63
+  frame.link = 63;
+  BOOST_REQUIRE_EQUAL(frame.link, 63);
+}
+
+BOOST_AUTO_TEST_CASE(RegularMembers)
+{
+  HSIFrame frame;
+  
+  frame.input_low = 0x11223344;
+  frame.input_high = 0x55667788;
+  frame.trigger = 0xDEADBEEF;
+  frame.sequence = 0xCAFEBABE;
+  
+  BOOST_REQUIRE_EQUAL(frame.input_low, 0x11223344);
+  BOOST_REQUIRE_EQUAL(frame.input_high, 0x55667788);
+  BOOST_REQUIRE_EQUAL(frame.trigger, 0xDEADBEEF);
+  BOOST_REQUIRE_EQUAL(frame.sequence, 0xCAFEBABE);
+}
+
+BOOST_AUTO_TEST_CASE(CompleteFrameSetup)
+{
+  HSIFrame frame = make_frame(
+    5,                    // version
+    3,                    // detector_id
+    7,                    // crate
+    2,                    // slot
+    42,                   // link
+    0x0123456789ABCDEF,   // timestamp
+    0x11111111,           // input_low
+    0x22222222,           // input_high
+    0x33333333,           // trigger
+    0x44444444            // sequence
+  );
+  
+  BOOST_REQUIRE_EQUAL(frame.version, 5);
+  BOOST_REQUIRE_EQUAL(frame.detector_id, 3);
+  BOOST_REQUIRE_EQUAL(frame.crate, 7);
+  BOOST_REQUIRE_EQUAL(frame.slot, 2);
+  BOOST_REQUIRE_EQUAL(frame.link, 42);
+  BOOST_REQUIRE_EQUAL(frame.get_timestamp(), 0x0123456789ABCDEF);
+  BOOST_REQUIRE_EQUAL(frame.input_low, 0x11111111);
+  BOOST_REQUIRE_EQUAL(frame.input_high, 0x22222222);
+  BOOST_REQUIRE_EQUAL(frame.trigger, 0x33333333);
+  BOOST_REQUIRE_EQUAL(frame.sequence, 0x44444444);
+}
+
+BOOST_AUTO_TEST_CASE(ByteRoundTrip)
+{
+  // Create a frame with specific values
+  HSIFrame original = make_frame(
+    5, 3, 7, 2, 42,
+    0x0123456789ABCDEF,
+    0x11111111, 0x22222222,
+    0x33333333, 0x44444444
+  );
+  
+  // Serialize to bytes
+  uint8_t buffer[ sizeof(HSIFrame) ];
+  std::memcpy(buffer, &original, sizeof(HSIFrame));
+
+  // Deserialize from bytes
+  HSIFrame recovered;
+  std::memcpy(&recovered, buffer, sizeof(HSIFrame));
+  
+  // Verify all fields match
+  BOOST_REQUIRE_EQUAL(recovered.version, original.version);
+  BOOST_REQUIRE_EQUAL(recovered.detector_id, original.detector_id);
+  BOOST_REQUIRE_EQUAL(recovered.crate, original.crate);
+  BOOST_REQUIRE_EQUAL(recovered.slot, original.slot);
+  BOOST_REQUIRE_EQUAL(recovered.link, original.link);
+  BOOST_REQUIRE_EQUAL(recovered.get_timestamp(), original.get_timestamp());
+  BOOST_REQUIRE_EQUAL(recovered.input_low, original.input_low);
+  BOOST_REQUIRE_EQUAL(recovered.input_high, original.input_high);
+  BOOST_REQUIRE_EQUAL(recovered.trigger, original.trigger);
+  BOOST_REQUIRE_EQUAL(recovered.sequence, original.sequence);
+}
+
+BOOST_AUTO_TEST_CASE(TimestampEndianness)
+{
+  HSIFrame frame;
+  
+  // Set timestamp to a value where endianness matters
+  uint64_t ts = 0x0102030405060708;
+  frame.set_timestamp(ts);
+  
+  // On little-endian: low 32 bits should be 0x05060708, high 32 bits should be 0x01020304
+  BOOST_REQUIRE_EQUAL(frame.timestamp_low, 0x05060708);
+  BOOST_REQUIRE_EQUAL(frame.timestamp_high, 0x01020304);
+  
+  // Verify get_timestamp reconstructs it correctly
+  BOOST_REQUIRE_EQUAL(frame.get_timestamp(), ts);
+}
+
+BOOST_AUTO_TEST_CASE(MultipleFramesIndependent)
+{
+  HSIFrame frame1 = make_frame(1, 1, 1, 1, 1, 0x1111111111111111, 0x11, 0x11, 0x11, 0x11);
+  HSIFrame frame2 = make_frame(2, 2, 2, 2, 2, 0x2222222222222222, 0x22, 0x22, 0x22, 0x22);
+  
+  // Verify they're independent
+  BOOST_REQUIRE_EQUAL(frame1.version, 1);
+  BOOST_REQUIRE_EQUAL(frame2.version, 2);
+  
+  BOOST_REQUIRE_EQUAL(frame1.get_timestamp(), 0x1111111111111111);
+  BOOST_REQUIRE_EQUAL(frame2.get_timestamp(), 0x2222222222222222);
+  
+  // Modify frame1, verify frame2 unchanged
+    frame1.version = 5;  // Use a value that fits in 6 bits
+      BOOST_REQUIRE_EQUAL(frame1.version, 5);
+    BOOST_REQUIRE_EQUAL(frame1.version, 5);
+  BOOST_REQUIRE_EQUAL(frame2.version, 2);
+}
+
+BOOST_AUTO_TEST_CASE(EdgeCaseHighBitfieldValues)
+{
+  HSIFrame frame;
+  
+  // Set all bitfields to maximum valid values for their bit widths
+  frame.version = (1u << 6) - 1;         // 6 bits: 0x3F = 63
+  frame.detector_id = (1u << 6) - 1;     // 6 bits: 0x3F = 63
+  frame.crate = (1u << 10) - 1;          // 10 bits: 0x3FF = 1023
+  frame.slot = (1u << 4) - 1;            // 4 bits: 0xF = 15
+  frame.link = (1u << 6) - 1;            // 6 bits: 0x3F = 63
+  
+  // Verify all are at max
+  BOOST_REQUIRE_EQUAL(frame.version, 63);
+  BOOST_REQUIRE_EQUAL(frame.detector_id, 63);
+  BOOST_REQUIRE_EQUAL(frame.crate, 1023);
+  BOOST_REQUIRE_EQUAL(frame.slot, 15);
+  BOOST_REQUIRE_EQUAL(frame.link, 63);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/unittest/HSIFrame_test.cxx
+++ b/unittest/HSIFrame_test.cxx
@@ -14,8 +14,12 @@
 
 #include <cstring>
 #include <limits>
+#include <vector>
 
 using namespace dunedaq::detdataformats;
+
+// Unit tests for a data formats library can expect to work with a lot of unsigned integers
+// NOLINTBEGIN(build/unsigned)
 
 namespace {
   // Helper to create HSIFrame from individual components
@@ -37,7 +41,7 @@ namespace {
     frame.sequence = sequence;
     return frame;
   }
-}
+} // namespace ""
 
 BOOST_AUTO_TEST_SUITE(HSIFrame_test)
 
@@ -200,7 +204,7 @@ BOOST_AUTO_TEST_CASE(ByteRoundTrip)
   );
   
   // Serialize to bytes
-  uint8_t buffer[ sizeof(HSIFrame) ];
+  uint8_t buffer[ sizeof(HSIFrame) ]; // NOLINT(modernize-avoid-c-arrays)
   std::memcpy(buffer, &original, sizeof(HSIFrame));
 
   // Deserialize from bytes
@@ -275,3 +279,5 @@ BOOST_AUTO_TEST_CASE(EdgeCaseHighBitfieldValues)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+
+// NOLINTEND(build/unsigned)


### PR DESCRIPTION
# Description

This is a refactor of the existing code, along with the addition of tests and the removal of a little unused API surface; it can be considered part of Issue #100, which itself falls under the umbrella of DUNE-DAQ/daq-deliverables#215. 

Further details can be found in the commit statements themselves, but broadly speaking, this PR will:
* Add unit tests for `HSIFrame`, `DAQHeader` and `DAQEthHeader`, none of which previously had unit tests
* Add Python scripts in a new `scripts/` directory which can be run to test the Python bindings in this package
* Mitigate the general layout uncertainty introduced by bit fields by (1) not using them when they're not necessary, and (2) running static_asserts to check endianness
* Further ensuring layout safety by checking structure size to guard against compiler padding, checking offsets, and checking that structures have standard layout and are trivially copyable
* Separate implementation from interface by, e.g., moving streaming operators into `*.hxx` files
* Remove unused API surface. This includes the `DetID::to_string` function as well as the `version` field of `DetID`, which I don't see used anywhere. If we're going to re-introduce it I feel like it should be under the condition that we put in PRs for code which use it in downstream packages. 
* Added Python bindings which were just missing (e.g., `kVD_BernCRT` and `kVD_GrenobleCRT` enum values for `DetID`) or which help with testing other Python bindings. 

Testing the changes will involve:
* Running the new tests and seeing that they all pass
* Ensuring that the rest the of the codebase is unaffected, since this is a refactor PR - in other words, regression testing

Note that suggestions which will affect the interface should be implemented in a separate PR. Note also that after this PR is approved the code will be run through `clang-format`. 

A test build using this feature branch was created for testing purposes, `DDFFD_DEV_260427_A9`. 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [X ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [X] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`) (*)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

(*) One thing went wrong during the integration tests, but it's not related to this PR and is the sort of thing we see occasionally in our nightlies: in the tpstream test there was `There were 2 failures to insert data into the latency buffer out of 4882 attempts in the latest monitoring interval.`

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [x] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [x] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

