### PR TITLE
JCF: Issue #100: clang-format the code

### DIFF
--- a/include/detdataformats/DAQEthHeader.hpp
+++ b/include/detdataformats/DAQEthHeader.hpp
@@ -1,5 +1,5 @@
 /**
- * @file DAQEthHeader.hpp Common header structure that is used by 
+ * @file DAQEthHeader.hpp Common header structure that is used by
  * every FrontEnd electronics board sending data over ethernet.
  *
  * This is part of the DUNE DAQ Application Framework, copyright 2020.
@@ -19,20 +19,22 @@ namespace dunedaq::detdataformats {
 /**
  * @brief DAQEthHeader is a versioned and unified structure for every FE electronics.
  */
-struct DAQEthHeader 
+struct DAQEthHeader
 {
   using word_t = uint64_t; // NOLINT(build/unsigned)
 
-  word_t version : 6, det_id : 6, crate_id : 10, slot_id : 4, stream_id : 8, reserved : 6, seq_id : 12, block_length : 12;
-  word_t timestamp { std::numeric_limits<word_t>::max() };
+  word_t version : 6, det_id : 6, crate_id : 10, slot_id : 4, stream_id : 8, reserved : 6, seq_id : 12,
+    block_length : 12;
+  word_t timestamp{ std::numeric_limits<word_t>::max() };
 
   uint64_t get_timestamp() const // NOLINT(build/unsigned) maintain a consistent interface with DAQHeader
   {
     return timestamp;
-  } 
+  }
 };
 
-std::ostream& operator<<(std::ostream& o, DAQEthHeader const& h);
+std::ostream&
+operator<<(std::ostream& o, DAQEthHeader const& h);
 
 } // namespace dunedaq::detdataformats
 

--- a/include/detdataformats/DAQHeader.hpp
+++ b/include/detdataformats/DAQHeader.hpp
@@ -1,5 +1,5 @@
 /**
- * @file DAQHeader.hpp Common header structure that is used by 
+ * @file DAQHeader.hpp Common header structure that is used by
  * every FrontEnd electronics board.
  *
  * This is part of the DUNE DAQ Application Framework, copyright 2020.
@@ -19,21 +19,22 @@ namespace dunedaq::detdataformats {
 /**
  * @brief DAQHeader is a versioned and unified structure for every FE electronics.
  */
-struct DAQHeader 
+struct DAQHeader
 {
   using word_t = uint32_t; // NOLINT(build/unsigned)
 
   word_t version : 6, det_id : 6, crate_id : 10, slot_id : 4, link_id : 6;
-  word_t timestamp_1 { std::numeric_limits<word_t>::max() };
-  word_t timestamp_2 { std::numeric_limits<word_t>::max() };
+  word_t timestamp_1{ std::numeric_limits<word_t>::max() };
+  word_t timestamp_2{ std::numeric_limits<word_t>::max() };
 
   uint64_t get_timestamp() const // NOLINT(build/unsigned)
   {
     return static_cast<uint64_t>(timestamp_1) | (static_cast<uint64_t>(timestamp_2) << 32); // NOLINT(build/unsigned)
-  } 
+  }
 };
 
-std::ostream& operator<<(std::ostream& o, DAQHeader const& h);
+std::ostream&
+operator<<(std::ostream& o, DAQHeader const& h);
 
 } // namespace dunedaq::detdataformats
 

--- a/include/detdataformats/DetID.hpp
+++ b/include/detdataformats/DetID.hpp
@@ -58,15 +58,18 @@ struct DetID
   DetID() = default;
 
   DetID(const Subdetector& subdetector_arg) // NOLINT(runtime/explicit) as DetID is just an enhanced enum
-     : subdetector(subdetector_arg)
-   {}
+    : subdetector(subdetector_arg)
+  {
+  }
 
   static std::string subdetector_to_string(const Subdetector& type);
   static Subdetector string_to_subdetector(const std::string& typestring);
 };
 
-  std::ostream& operator<<(std::ostream& o, DetID const& det_id);
-  std::istream& operator>>(std::istream& is, DetID& det_id);
+std::ostream&
+operator<<(std::ostream& o, DetID const& det_id);
+std::istream&
+operator>>(std::istream& is, DetID& det_id);
 
 } // namespace dunedaq::detdataformats
 

--- a/include/detdataformats/HSIFrame.hpp
+++ b/include/detdataformats/HSIFrame.hpp
@@ -11,7 +11,7 @@
 #ifndef DETDATAFORMATS_INCLUDE_DETDATAFORMATS_HSIFRAME_HPP_
 #define DETDATAFORMATS_INCLUDE_DETDATAFORMATS_HSIFRAME_HPP_
 
-#include <cstdint>  // For uint32_t etc
+#include <cstdint> // For uint32_t etc
 #include <limits>
 
 namespace dunedaq::detdataformats {
@@ -23,16 +23,17 @@ public:
   using word_t = uint32_t; // NOLINT
 
   word_t version : 6, detector_id : 6, crate : 10, slot : 4, link : 6;
-  word_t timestamp_low { std::numeric_limits<word_t>::max() } ;
-  word_t timestamp_high { std::numeric_limits<word_t>::max() } ;
-  word_t input_low { std::numeric_limits<word_t>::max() } ;
-  word_t input_high { std::numeric_limits<word_t>::max() } ;
-  word_t trigger { std::numeric_limits<word_t>::max() } ;
-  word_t sequence { std::numeric_limits<word_t>::max() } ;
+  word_t timestamp_low{ std::numeric_limits<word_t>::max() };
+  word_t timestamp_high{ std::numeric_limits<word_t>::max() };
+  word_t input_low{ std::numeric_limits<word_t>::max() };
+  word_t input_high{ std::numeric_limits<word_t>::max() };
+  word_t trigger{ std::numeric_limits<word_t>::max() };
+  word_t sequence{ std::numeric_limits<word_t>::max() };
 
   uint64_t get_timestamp() const // NOLINT(build/unsigned)
   {
-    return static_cast<uint64_t>(timestamp_low) | (static_cast<uint64_t>(timestamp_high) << 32); // NOLINT(build/unsigned)
+    return static_cast<uint64_t>(timestamp_low) |         // NOLINT(build/unsigned)
+           (static_cast<uint64_t>(timestamp_high) << 32); // NOLINT(build/unsigned)
   }
 
   void set_timestamp(uint64_t ts) // NOLINT(build/unsigned)

--- a/include/detdataformats/detail/DAQEthHeader.hxx
+++ b/include/detdataformats/detail/DAQEthHeader.hxx
@@ -1,26 +1,24 @@
 
 namespace dunedaq::detdataformats {
 
-  static_assert(std::endian::native == std::endian::little, "The DAQEthHeader bitfield layout assumes little-endian architecture");
+static_assert(std::endian::native == std::endian::little,
+              "The DAQEthHeader bitfield layout assumes little-endian architecture");
 
-  static_assert(std::is_trivially_copyable_v<DAQEthHeader>, "DAQEthHeader isn't trivially copyable and can't be safely std::memcpy'd");
-  static_assert(std::is_standard_layout_v<DAQEthHeader>, "DAQEthHeader isn't standard layout; reinterpret_cast and offsetof can't safely be used with it");
+static_assert(std::is_trivially_copyable_v<DAQEthHeader>,
+              "DAQEthHeader isn't trivially copyable and can't be safely std::memcpy'd");
+static_assert(std::is_standard_layout_v<DAQEthHeader>,
+              "DAQEthHeader isn't standard layout; reinterpret_cast and offsetof can't safely be used with it");
 
-  static_assert(sizeof(DAQEthHeader) == 16, "DAQEthHeader not the expected size");
-  static_assert(offsetof(DAQEthHeader, timestamp) == 8, "timestamp field not at expected offset");
+static_assert(sizeof(DAQEthHeader) == 16, "DAQEthHeader not the expected size");
+static_assert(offsetof(DAQEthHeader, timestamp) == 8, "timestamp field not at expected offset");
 
-  inline std::ostream&
-  operator<<(std::ostream& o, DAQEthHeader const& h)
-  {
-    return o << "Version:" << static_cast<unsigned>(h.version) <<
-      " DetID:" << static_cast<unsigned>(h.det_id) <<
-      " CrateID:" << static_cast<unsigned>(h.crate_id) <<
-	" SlotID:" << static_cast<unsigned>(h.slot_id) <<
-	  " StreamID:" << static_cast<unsigned>(h.stream_id) <<
-	    " SequenceID: " << static_cast<unsigned>(h.seq_id) <<
-	      " Block length: " << static_cast<unsigned>(h.block_length) <<
-	      " Timestamp: " << h.get_timestamp() <<
-	      '\n';
-  }
+inline std::ostream&
+operator<<(std::ostream& o, DAQEthHeader const& h)
+{
+  return o << "Version:" << static_cast<unsigned>(h.version) << " DetID:" << static_cast<unsigned>(h.det_id)
+           << " CrateID:" << static_cast<unsigned>(h.crate_id) << " SlotID:" << static_cast<unsigned>(h.slot_id)
+           << " StreamID:" << static_cast<unsigned>(h.stream_id) << " SequenceID: " << static_cast<unsigned>(h.seq_id)
+           << " Block length: " << static_cast<unsigned>(h.block_length) << " Timestamp: " << h.get_timestamp() << '\n';
+}
 
 } // namespace dunedaq::detdataformats

--- a/include/detdataformats/detail/DAQHeader.hxx
+++ b/include/detdataformats/detail/DAQHeader.hxx
@@ -1,12 +1,14 @@
 
-#include <type_traits>
 #include <bit>
 #include <cstddef>
+#include <type_traits>
 
 namespace dunedaq::detdataformats {
 
-static_assert(std::is_trivially_copyable_v<DAQHeader>, "DAQHeader isn't trivially copyable and can't be safely std::memcpy'd");
-static_assert(std::is_standard_layout_v<DAQHeader>, "DAQHeader isn't standard layout; reinterpret_cast and offsetof can't safely be used with it");
+static_assert(std::is_trivially_copyable_v<DAQHeader>,
+              "DAQHeader isn't trivially copyable and can't be safely std::memcpy'd");
+static_assert(std::is_standard_layout_v<DAQHeader>,
+              "DAQHeader isn't standard layout; reinterpret_cast and offsetof can't safely be used with it");
 static_assert(std::endian::native == std::endian::little,
               "The DAQHeader bitfield layout assumes little-endian architecture");
 
@@ -14,17 +16,12 @@ static_assert(sizeof(DAQHeader) == 12, "DAQHeader struct size different than exp
 static_assert(offsetof(DAQHeader, timestamp_1) == 4, "DAQHeader timestamp_1 field not at expected offset");
 static_assert(offsetof(DAQHeader, timestamp_2) == 8, "DAQHeader timestamp_2 field not at expected offset");
 
-
 inline std::ostream&
 operator<<(std::ostream& o, DAQHeader const& h)
 {
-  return o << "Version:" << static_cast<unsigned>(h.version) <<
-    " DetID:" << static_cast<unsigned>(h.det_id) <<
-    " CrateID:" << static_cast<unsigned>(h.crate_id) <<
-    " SlotID:" << static_cast<unsigned>(h.slot_id) <<
-      " LinkID:" << static_cast<unsigned>(h.link_id) <<
-      " Timestamp: " << h.get_timestamp() <<
-      '\n';
+  return o << "Version:" << static_cast<unsigned>(h.version) << " DetID:" << static_cast<unsigned>(h.det_id)
+           << " CrateID:" << static_cast<unsigned>(h.crate_id) << " SlotID:" << static_cast<unsigned>(h.slot_id)
+           << " LinkID:" << static_cast<unsigned>(h.link_id) << " Timestamp: " << h.get_timestamp() << '\n';
 }
 
 } // namespace dunedaq::detdataformats

--- a/include/detdataformats/detail/DetID.hxx
+++ b/include/detdataformats/detail/DetID.hxx
@@ -22,7 +22,7 @@ operator<<(std::ostream& o, DetID::Subdetector const& type)
 inline std::ostream&
 operator<<(std::ostream& o, DetID const& det_id)
 {
-  return o << "subdetector: " << det_id.subdetector ;
+  return o << "subdetector: " << det_id.subdetector;
 }
 
 /**
@@ -51,7 +51,7 @@ inline std::istream&
 operator>>(std::istream& is, DetID& det_id)
 {
   std::string tmp;
-  is >> tmp >> det_id.subdetector; 
+  is >> tmp >> det_id.subdetector;
 
   return is;
 }

--- a/include/detdataformats/detail/HSIFrame.hxx
+++ b/include/detdataformats/detail/HSIFrame.hxx
@@ -1,12 +1,14 @@
 
-#include <type_traits>
 #include <bit>
 #include <cstddef>
+#include <type_traits>
 
 namespace dunedaq::detdataformats {
 
-static_assert(std::is_trivially_copyable_v<HSIFrame>, "HSIFrame isn't trivially copyable and can't be safely std::memcpy'd");
-static_assert(std::is_standard_layout_v<HSIFrame>, "HSIFrame isn't standard layout; reinterpret_cast and offsetof can't safely be used with it");
+static_assert(std::is_trivially_copyable_v<HSIFrame>,
+              "HSIFrame isn't trivially copyable and can't be safely std::memcpy'd");
+static_assert(std::is_standard_layout_v<HSIFrame>,
+              "HSIFrame isn't standard layout; reinterpret_cast and offsetof can't safely be used with it");
 static_assert(std::endian::native == std::endian::little,
               "The HSIFrame bitfield layout assumes little-endian architecture");
 

--- a/pybindsrc/daqethheader.cpp
+++ b/pybindsrc/daqethheader.cpp
@@ -18,8 +18,8 @@ namespace py = pybind11;
 
 namespace dunedaq::detdataformats::python {
 
-  // Quiet the linter about use of unsigned ints in the file
-  // NOLINTBEGIN(build/unsigned)
+// Quiet the linter about use of unsigned ints in the file
+// NOLINTBEGIN(build/unsigned)
 
 void
 register_daqethheader(py::module& m)

--- a/pybindsrc/daqheader.cpp
+++ b/pybindsrc/daqheader.cpp
@@ -18,49 +18,50 @@ namespace py = pybind11;
 
 namespace dunedaq::detdataformats::python {
 
-  // Quiet the linter about use of unsigned ints in the file
-  // NOLINTBEGIN(build/unsigned)
+// Quiet the linter about use of unsigned ints in the file
+// NOLINTBEGIN(build/unsigned)
 
-void register_daqheader(py::module& m) {
+void
+register_daqheader(py::module& m)
+{
 
   py::class_<DAQHeader>(m, "DAQHeader", py::buffer_protocol())
     .def(py::init<>())
-    .def_property("version", 
+    .def_property(
+      "version",
       [](DAQHeader& self) -> uint32_t { return self.version; },
-      [](DAQHeader& self, uint32_t version) { self.version = version; }
-      )
-    .def_property("det_id", 
+      [](DAQHeader& self, uint32_t version) { self.version = version; })
+    .def_property(
+      "det_id",
       [](DAQHeader& self) -> uint32_t { return self.det_id; },
-      [](DAQHeader& self, uint32_t det_id) { self.det_id = det_id; }
-      )
-    .def_property("crate_id", 
+      [](DAQHeader& self, uint32_t det_id) { self.det_id = det_id; })
+    .def_property(
+      "crate_id",
       [](DAQHeader& self) -> uint32_t { return self.crate_id; },
-      [](DAQHeader& self, uint32_t crate_id) { self.crate_id = crate_id; }
-      )
-    .def_property("slot_id", 
+      [](DAQHeader& self, uint32_t crate_id) { self.crate_id = crate_id; })
+    .def_property(
+      "slot_id",
       [](DAQHeader& self) -> uint32_t { return self.slot_id; },
-      [](DAQHeader& self, uint32_t slot_id) { self.slot_id = slot_id; }
-      )
-    .def_property("link_id", 
+      [](DAQHeader& self, uint32_t slot_id) { self.slot_id = slot_id; })
+    .def_property(
+      "link_id",
       [](DAQHeader& self) -> uint32_t { return self.link_id; },
-      [](DAQHeader& self, uint32_t link_id) { self.link_id = link_id; }
-      )
-    .def_property("timestamp_1", 
-      [](DAQHeader& ) -> uint32_t { 
-        throw std::runtime_error("Cannot directly read timestamp_1; use get_timestamp() instead"); 
+      [](DAQHeader& self, uint32_t link_id) { self.link_id = link_id; })
+    .def_property(
+      "timestamp_1",
+      [](DAQHeader&) -> uint32_t {
+        throw std::runtime_error("Cannot directly read timestamp_1; use get_timestamp() instead");
       },
-      [](DAQHeader& self, uint32_t timestamp_1) { self.timestamp_1 = timestamp_1; }
-      )
-    .def_property("timestamp_2", 
-      [](DAQHeader& ) -> uint32_t { 
-        throw std::runtime_error("Cannot directly read timestamp_2; use get_timestamp() instead"); 
+      [](DAQHeader& self, uint32_t timestamp_1) { self.timestamp_1 = timestamp_1; })
+    .def_property(
+      "timestamp_2",
+      [](DAQHeader&) -> uint32_t {
+        throw std::runtime_error("Cannot directly read timestamp_2; use get_timestamp() instead");
       },
-      [](DAQHeader& self, uint32_t timestamp_2) { self.timestamp_2 = timestamp_2; }
-      )
-    .def("get_timestamp", &DAQHeader::get_timestamp)
-    ;
+      [](DAQHeader& self, uint32_t timestamp_2) { self.timestamp_2 = timestamp_2; })
+    .def("get_timestamp", &DAQHeader::get_timestamp);
 }
 
-}  // namespace dunedaq::detdataformats::python
+} // namespace dunedaq::detdataformats::python
 
 // NOLINTEND(build/unsigned)

--- a/pybindsrc/detid.cpp
+++ b/pybindsrc/detid.cpp
@@ -18,37 +18,39 @@ namespace py = pybind11;
 
 namespace dunedaq::detdataformats::python {
 
-void register_detid(py::module& m) {
+void
+register_detid(py::module& m)
+{
   py::class_<DetID> py_detid(m, "DetID");
   py_detid.def(py::init())
-      .def(py::init<const DetID::Subdetector&>())
-      .def("__repr__", [](const DetID& gid) {
-        std::ostringstream oss;
-        oss << "<detdataformats::DetID " << DetID::subdetector_to_string(gid.subdetector) << ">";
-        return oss.str();
-      })
-      .def("subdetector_to_string", &DetID::subdetector_to_string)
-      .def("string_to_subdetector", &DetID::string_to_subdetector);
+    .def(py::init<const DetID::Subdetector&>())
+    .def("__repr__",
+         [](const DetID& gid) {
+           std::ostringstream oss;
+           oss << "<detdataformats::DetID " << DetID::subdetector_to_string(gid.subdetector) << ">";
+           return oss.str();
+         })
+    .def("subdetector_to_string", &DetID::subdetector_to_string)
+    .def("string_to_subdetector", &DetID::string_to_subdetector);
 
   py::enum_<DetID::Subdetector>(py_detid, "Subdetector")
-      .value("kUnknown", DetID::Subdetector::kUnknown)
-      .value("kDAQ", DetID::Subdetector::kDAQ)
-      .value("kHD_PDS", DetID::Subdetector::kHD_PDS)
-      .value("kHD_TPC", DetID::Subdetector::kHD_TPC)
-      .value("kHD_CRT", DetID::Subdetector::kHD_CRT)
-      .value("kVD_CathodePDS", DetID::Subdetector::kVD_CathodePDS)
-      .value("kVD_MembranePDS", DetID::Subdetector::kVD_MembranePDS)
-      .value("kVD_BottomTPC", DetID::Subdetector::kVD_BottomTPC)
-      .value("kVD_TopTPC", DetID::Subdetector::kVD_TopTPC)
-      .value("kVD_BernCRT", DetID::Subdetector::kVD_BernCRT)
-      .value("kVD_GrenobleCRT", DetID::Subdetector::kVD_GrenobleCRT)
-      .value("kNDLAr_TPC", DetID::Subdetector::kNDLAr_TPC)
-      .value("kNDLAr_PDS", DetID::Subdetector::kNDLAr_PDS)
-      .value("kND_GAr", DetID::Subdetector::kND_GAr)
-      .export_values();
+    .value("kUnknown", DetID::Subdetector::kUnknown)
+    .value("kDAQ", DetID::Subdetector::kDAQ)
+    .value("kHD_PDS", DetID::Subdetector::kHD_PDS)
+    .value("kHD_TPC", DetID::Subdetector::kHD_TPC)
+    .value("kHD_CRT", DetID::Subdetector::kHD_CRT)
+    .value("kVD_CathodePDS", DetID::Subdetector::kVD_CathodePDS)
+    .value("kVD_MembranePDS", DetID::Subdetector::kVD_MembranePDS)
+    .value("kVD_BottomTPC", DetID::Subdetector::kVD_BottomTPC)
+    .value("kVD_TopTPC", DetID::Subdetector::kVD_TopTPC)
+    .value("kVD_BernCRT", DetID::Subdetector::kVD_BernCRT)
+    .value("kVD_GrenobleCRT", DetID::Subdetector::kVD_GrenobleCRT)
+    .value("kNDLAr_TPC", DetID::Subdetector::kNDLAr_TPC)
+    .value("kNDLAr_PDS", DetID::Subdetector::kNDLAr_PDS)
+    .value("kND_GAr", DetID::Subdetector::kND_GAr)
+    .export_values();
 
-      py_detid.def_readwrite("subdetector", &DetID::subdetector);
+  py_detid.def_readwrite("subdetector", &DetID::subdetector);
 }
 
-}  // namespace dunedaq::detdataformats::python
-
+} // namespace dunedaq::detdataformats::python

--- a/pybindsrc/hsi.cpp
+++ b/pybindsrc/hsi.cpp
@@ -16,34 +16,33 @@ namespace dunedaq::detdataformats::python {
 
 // Quiet the linter about use of unsigned ints in the file
 // NOLINTBEGIN(build/unsigned)
-  
+
 void
 register_hsi(py::module& m)
 {
 
-  py::class_<HSIFrame> (m, "HSIFrame", py::buffer_protocol())
+  py::class_<HSIFrame>(m, "HSIFrame", py::buffer_protocol())
     .def(py::init())
     .def(py::init([](py::capsule capsule) {
-        auto hsfp = *static_cast<HSIFrame*>(capsule.get_pointer());
-        return hsfp;
-    } ))
-    .def(py::init([](py::bytes bytes){
+      auto hsfp = *static_cast<HSIFrame*>(capsule.get_pointer());
+      return hsfp;
+    }))
+    .def(py::init([](py::bytes bytes) {
       py::buffer_info info(py::buffer(bytes).request());
       auto wfp = *static_cast<HSIFrame*>(info.ptr);
       return wfp;
     }))
     .def("get_timestamp", &HSIFrame::get_timestamp)
-    .def_property_readonly("version", [](const HSIFrame& self) -> uint64_t {return self.version;})
-    .def_property_readonly("detector_id", [](const HSIFrame& self) -> uint64_t {return self.detector_id;})
-    .def_property_readonly("crate", [](const HSIFrame& self) -> uint64_t {return self.crate;})
-    .def_property_readonly("slot", [](const HSIFrame& self) -> uint64_t {return self.slot;})
-    .def_property_readonly("link", [](const HSIFrame& self) -> uint64_t {return self.link;})
-    .def_property_readonly("input_low", [](const HSIFrame& self) -> uint64_t {return self.input_low;})
-    .def_property_readonly("input_high", [](const HSIFrame& self) -> uint64_t {return self.input_high;})
-    .def_property_readonly("trigger", [](const HSIFrame& self) -> uint64_t {return self.trigger;})
-    .def_property_readonly("sequence", [](const HSIFrame& self) -> uint64_t {return self.sequence;})
-    .def_static("sizeof", [](){ return sizeof(HSIFrame); })
-  ;
+    .def_property_readonly("version", [](const HSIFrame& self) -> uint64_t { return self.version; })
+    .def_property_readonly("detector_id", [](const HSIFrame& self) -> uint64_t { return self.detector_id; })
+    .def_property_readonly("crate", [](const HSIFrame& self) -> uint64_t { return self.crate; })
+    .def_property_readonly("slot", [](const HSIFrame& self) -> uint64_t { return self.slot; })
+    .def_property_readonly("link", [](const HSIFrame& self) -> uint64_t { return self.link; })
+    .def_property_readonly("input_low", [](const HSIFrame& self) -> uint64_t { return self.input_low; })
+    .def_property_readonly("input_high", [](const HSIFrame& self) -> uint64_t { return self.input_high; })
+    .def_property_readonly("trigger", [](const HSIFrame& self) -> uint64_t { return self.trigger; })
+    .def_property_readonly("sequence", [](const HSIFrame& self) -> uint64_t { return self.sequence; })
+    .def_static("sizeof", []() { return sizeof(HSIFrame); });
 }
 
 } // namespace dunedaq::detdataformats::python

--- a/pybindsrc/module.cpp
+++ b/pybindsrc/module.cpp
@@ -13,15 +13,15 @@
 
 namespace dunedaq::detdataformats::python {
 
-PYBIND11_MODULE(_daq_detdataformats_py, m) {
+PYBIND11_MODULE(_daq_detdataformats_py, m)
+{
 
-    m.doc() = "c++ implementation of the dunedaq detdataformats modules"; // optional module docstring
+  m.doc() = "c++ implementation of the dunedaq detdataformats modules"; // optional module docstring
 
-    register_detid(m);
-    register_daqheader(m);
-    register_daqethheader(m);
-    register_hsi(m);
-
+  register_detid(m);
+  register_daqheader(m);
+  register_daqethheader(m);
+  register_hsi(m);
 }
 
 } // namespace dunedaq::detdataformats::python

--- a/pybindsrc/registrators.hpp
+++ b/pybindsrc/registrators.hpp
@@ -8,7 +8,6 @@
  * received with this code.
  */
 
-
 #ifndef DETDATAFORMATS_PYBINDSRC_REGISTRATORS_HPP_
 #define DETDATAFORMATS_PYBINDSRC_REGISTRATORS_HPP_
 
@@ -16,10 +15,14 @@
 
 namespace dunedaq::detdataformats::python {
 
-  void register_detid(pybind11::module&);
-  void register_daqheader(pybind11::module&);
-  void register_daqethheader(pybind11::module&);
-  void register_hsi(pybind11::module&);
+void
+register_detid(pybind11::module&);
+void
+register_daqheader(pybind11::module&);
+void
+register_daqethheader(pybind11::module&);
+void
+register_hsi(pybind11::module&);
 } // namespace dunedaq::detdataformats::python
 
 #endif // DETDATAFORMATS_PYBINDSRC_REGISTRATORS_HPP_

--- a/unittest/DAQEthHeader_test.cxx
+++ b/unittest/DAQEthHeader_test.cxx
@@ -8,7 +8,7 @@
 
 #include "detdataformats/DAQEthHeader.hpp"
 
-#define BOOST_TEST_MODULE DAQEthHeader_test  // NOLINT
+#define BOOST_TEST_MODULE DAQEthHeader_test // NOLINT
 
 #include "boost/test/unit_test.hpp"
 
@@ -70,23 +70,23 @@ header_from_stream_output(const std::string& output)
   std::string timestamp_label;
   uint64_t timestamp_value{};
 
-  iss >> version_token >> det_id_token >> crate_id_token >> slot_id_token >> stream_id_token >> sequence_label >> sequence_value >> block_label >> block_length_label >> block_length_value >> timestamp_label >> timestamp_value;
+  iss >> version_token >> det_id_token >> crate_id_token >> slot_id_token >> stream_id_token >> sequence_label >>
+    sequence_value >> block_label >> block_length_label >> block_length_value >> timestamp_label >> timestamp_value;
 
   BOOST_REQUIRE_EQUAL(sequence_label, "SequenceID:");
   BOOST_REQUIRE_EQUAL(block_label, "Block");
   BOOST_REQUIRE_EQUAL(block_length_label, "length:");
   BOOST_REQUIRE_EQUAL(timestamp_label, "Timestamp:");
 
-  return make_header(
-    static_cast<word_t>(std::stoull(version_token.substr(std::string("Version:").size()))),
-    static_cast<word_t>(std::stoull(det_id_token.substr(std::string("DetID:").size()))),
-    static_cast<word_t>(std::stoull(crate_id_token.substr(std::string("CrateID:").size()))),
-    static_cast<word_t>(std::stoull(slot_id_token.substr(std::string("SlotID:").size()))),
-    static_cast<word_t>(std::stoull(stream_id_token.substr(std::string("StreamID:").size()))),
-    0,
-    static_cast<word_t>(sequence_value),
-    static_cast<word_t>(block_length_value),
-    static_cast<word_t>(timestamp_value));
+  return make_header(static_cast<word_t>(std::stoull(version_token.substr(std::string("Version:").size()))),
+                     static_cast<word_t>(std::stoull(det_id_token.substr(std::string("DetID:").size()))),
+                     static_cast<word_t>(std::stoull(crate_id_token.substr(std::string("CrateID:").size()))),
+                     static_cast<word_t>(std::stoull(slot_id_token.substr(std::string("SlotID:").size()))),
+                     static_cast<word_t>(std::stoull(stream_id_token.substr(std::string("StreamID:").size()))),
+                     0,
+                     static_cast<word_t>(sequence_value),
+                     static_cast<word_t>(block_length_value),
+                     static_cast<word_t>(timestamp_value));
 }
 } // namespace ""
 
@@ -110,11 +110,7 @@ BOOST_AUTO_TEST_CASE(TimestampAccess)
 BOOST_AUTO_TEST_CASE(TimestampRoundTripFromGetTimestamp)
 {
   const std::vector<word_t> values = {
-    0x0000000000000000ULL,
-    0x0000000000000001ULL,
-    0x0123456789ABCDEFULL,
-    0xFEDCBA9876543210ULL,
-    0xFFFFFFFFFFFFFFFFULL
+    0x0000000000000000ULL, 0x0000000000000001ULL, 0x0123456789ABCDEFULL, 0xFEDCBA9876543210ULL, 0xFFFFFFFFFFFFFFFFULL
   };
 
   for (const auto& value : values) {
@@ -143,14 +139,14 @@ BOOST_AUTO_TEST_CASE(BitfieldMasking)
 {
   DAQEthHeader header = make_header(0, 0, 0, 0, 0, 0, 0, 0, 0);
 
-  header.version = 99;         // NOLINT 99 & 0x3F = 35
-  header.det_id = 127;         // NOLINT 127 & 0x3F = 63
-  header.crate_id = 2048;      // NOLINT 2048 & 0x3FF = 0
-  header.slot_id = 31;         // NOLINT 31 & 0x0F = 15
-  header.stream_id = 511;      // NOLINT 511 & 0xFF = 255
-  header.reserved = 127;       // NOLINT 127 & 0x3F = 63
-  header.seq_id = 5000;        // NOLINT 5000 & 0xFFF = 904
-  header.block_length = 5000;  // NOLINT 5000 & 0xFFF = 904
+  header.version = 99;        // NOLINT 99 & 0x3F = 35
+  header.det_id = 127;        // NOLINT 127 & 0x3F = 63
+  header.crate_id = 2048;     // NOLINT 2048 & 0x3FF = 0
+  header.slot_id = 31;        // NOLINT 31 & 0x0F = 15
+  header.stream_id = 511;     // NOLINT 511 & 0xFF = 255
+  header.reserved = 127;      // NOLINT 127 & 0x3F = 63
+  header.seq_id = 5000;       // NOLINT 5000 & 0xFFF = 904
+  header.block_length = 5000; // NOLINT 5000 & 0xFFF = 904
 
   BOOST_REQUIRE_EQUAL(header.version, 35);
   BOOST_REQUIRE_EQUAL(header.det_id, 63);
@@ -164,16 +160,7 @@ BOOST_AUTO_TEST_CASE(BitfieldMasking)
 
 BOOST_AUTO_TEST_CASE(StreamOperatorRoundTrip)
 {
-  const DAQEthHeader original = make_header(
-    7,
-    3,
-    22,
-    4,
-    9,
-    0,
-    1234,
-    88,
-    0x0123456789ABCDEFULL);
+  const DAQEthHeader original = make_header(7, 3, 22, 4, 9, 0, 1234, 88, 0x0123456789ABCDEFULL);
 
   std::ostringstream oss;
   oss << original;
@@ -196,16 +183,7 @@ BOOST_AUTO_TEST_CASE(StreamOperatorRoundTrip)
 
 BOOST_AUTO_TEST_CASE(ByteRoundTrip)
 {
-  const DAQEthHeader original = make_header(
-    13,
-    21,
-    777,
-    10,
-    55,
-    6,
-    2048,
-    1024,
-    0x1122334455667788ULL);
+  const DAQEthHeader original = make_header(13, 21, 777, 10, 55, 6, 2048, 1024, 0x1122334455667788ULL);
 
   uint8_t buffer[sizeof(DAQEthHeader)]; // NOLINT(modernize-avoid-c-arrays)
   std::memcpy(buffer, &original, sizeof(DAQEthHeader));

--- a/unittest/DAQHeader_test.cxx
+++ b/unittest/DAQHeader_test.cxx
@@ -8,7 +8,7 @@
 
 #include "detdataformats/DAQHeader.hpp"
 
-#define BOOST_TEST_MODULE DAQHeader_test  // NOLINT
+#define BOOST_TEST_MODULE DAQHeader_test // NOLINT
 
 #include "boost/test/unit_test.hpp"
 
@@ -53,10 +53,7 @@ make_header(word_t version,
 std::pair<word_t, word_t>
 split_timestamp(uint64_t timestamp)
 {
-  return {
-    static_cast<word_t>(timestamp),
-    static_cast<word_t>(timestamp >> 32)
-  };
+  return { static_cast<word_t>(timestamp), static_cast<word_t>(timestamp >> 32) };
 }
 
 DAQHeader
@@ -72,18 +69,18 @@ header_from_stream_output(const std::string& output)
   std::string timestamp_label;
   uint64_t timestamp_value{};
 
-  iss >> version_token >> det_id_token >> crate_id_token >> slot_id_token >> link_id_token >> timestamp_label >> timestamp_value;
+  iss >> version_token >> det_id_token >> crate_id_token >> slot_id_token >> link_id_token >> timestamp_label >>
+    timestamp_value;
 
   const auto [timestamp_1, timestamp_2] = split_timestamp(timestamp_value);
 
-  return make_header(
-    static_cast<word_t>(std::stoul(version_token.substr(std::string("Version:").size()))),
-    static_cast<word_t>(std::stoul(det_id_token.substr(std::string("DetID:").size()))),
-    static_cast<word_t>(std::stoul(crate_id_token.substr(std::string("CrateID:").size()))),
-    static_cast<word_t>(std::stoul(slot_id_token.substr(std::string("SlotID:").size()))),
-    static_cast<word_t>(std::stoul(link_id_token.substr(std::string("LinkID:").size()))),
-    timestamp_1,
-    timestamp_2);
+  return make_header(static_cast<word_t>(std::stoul(version_token.substr(std::string("Version:").size()))),
+                     static_cast<word_t>(std::stoul(det_id_token.substr(std::string("DetID:").size()))),
+                     static_cast<word_t>(std::stoul(crate_id_token.substr(std::string("CrateID:").size()))),
+                     static_cast<word_t>(std::stoul(slot_id_token.substr(std::string("SlotID:").size()))),
+                     static_cast<word_t>(std::stoul(link_id_token.substr(std::string("LinkID:").size()))),
+                     timestamp_1,
+                     timestamp_2);
 }
 } // namespace ""
 
@@ -107,13 +104,11 @@ BOOST_AUTO_TEST_CASE(TimestampAssembly)
 
 BOOST_AUTO_TEST_CASE(TimestampRoundTripFromGetTimestamp)
 {
-  const std::vector<std::pair<word_t, word_t>> values = {
-    { 0x00000000u, 0x00000000u },
-    { 0xFFFFFFFFu, 0x00000000u },
-    { 0x00000000u, 0xFFFFFFFFu },
-    { 0x01234567u, 0x89ABCDEFu },
-    { 0xFFFFFFFFu, 0xFFFFFFFFu }
-  };
+  const std::vector<std::pair<word_t, word_t>> values = { { 0x00000000u, 0x00000000u },
+                                                          { 0xFFFFFFFFu, 0x00000000u },
+                                                          { 0x00000000u, 0xFFFFFFFFu },
+                                                          { 0x01234567u, 0x89ABCDEFu },
+                                                          { 0xFFFFFFFFu, 0xFFFFFFFFu } };
 
   for (const auto& value : values) {
     const DAQHeader original = make_header(0, 0, 0, 0, 0, value.first, value.second);
@@ -140,11 +135,11 @@ BOOST_AUTO_TEST_CASE(BitfieldMasking)
 {
   DAQHeader header = make_header(0, 0, 0, 0, 0, 0, 0);
 
-  header.version = 99;     // NOLINT 99 & 0x3F = 35
-  header.det_id = 127;     // NOLINT 127 & 0x3F = 63
-  header.crate_id = 2048;  // NOLINT 2048 & 0x3FF = 0
-  header.slot_id = 31;     // NOLINT 31 & 0x0F = 15
-  header.link_id = 65;     // NOLINT 65 & 0x3F = 1
+  header.version = 99;    // NOLINT 99 & 0x3F = 35
+  header.det_id = 127;    // NOLINT 127 & 0x3F = 63
+  header.crate_id = 2048; // NOLINT 2048 & 0x3FF = 0
+  header.slot_id = 31;    // NOLINT 31 & 0x0F = 15
+  header.link_id = 65;    // NOLINT 65 & 0x3F = 1
 
   BOOST_REQUIRE_EQUAL(header.version, 35);
   BOOST_REQUIRE_EQUAL(header.det_id, 63);

--- a/unittest/DetID_test.cxx
+++ b/unittest/DetID_test.cxx
@@ -9,7 +9,7 @@
 
 #include "detdataformats/DetID.hpp"
 
-#define BOOST_TEST_MODULE DetID_test  // NOLINT
+#define BOOST_TEST_MODULE DetID_test // NOLINT
 
 #include "boost/test/unit_test.hpp"
 
@@ -43,20 +43,13 @@ BOOST_AUTO_TEST_CASE(AllSubdetectorValues)
 {
   // Test all defined subdetector enum values
   const std::vector<DetID::Subdetector> all_subdetectors = {
-    DetID::Subdetector::kUnknown,
-    DetID::Subdetector::kDAQ,
-    DetID::Subdetector::kHD_PDS,
-    DetID::Subdetector::kHD_TPC,
-    DetID::Subdetector::kHD_CRT,
-    DetID::Subdetector::kVD_CathodePDS,
-    DetID::Subdetector::kVD_MembranePDS,
-    DetID::Subdetector::kVD_BottomTPC,
-    DetID::Subdetector::kVD_TopTPC,
-    DetID::Subdetector::kVD_BernCRT,
-    DetID::Subdetector::kVD_GrenobleCRT,
-    DetID::Subdetector::kNDLAr_TPC,
-    DetID::Subdetector::kNDLAr_PDS,
-    DetID::Subdetector::kND_GAr
+    DetID::Subdetector::kUnknown,        DetID::Subdetector::kDAQ,
+    DetID::Subdetector::kHD_PDS,         DetID::Subdetector::kHD_TPC,
+    DetID::Subdetector::kHD_CRT,         DetID::Subdetector::kVD_CathodePDS,
+    DetID::Subdetector::kVD_MembranePDS, DetID::Subdetector::kVD_BottomTPC,
+    DetID::Subdetector::kVD_TopTPC,      DetID::Subdetector::kVD_BernCRT,
+    DetID::Subdetector::kVD_GrenobleCRT, DetID::Subdetector::kNDLAr_TPC,
+    DetID::Subdetector::kNDLAr_PDS,      DetID::Subdetector::kND_GAr
   };
 
   for (const auto& subdet : all_subdetectors) {
@@ -106,27 +99,20 @@ BOOST_AUTO_TEST_CASE(StringToSubdetectorInvalid)
   // Invalid strings should fall back to kUnknown
   BOOST_REQUIRE_EQUAL(DetID::string_to_subdetector("InvalidName"), DetID::Subdetector::kUnknown);
   BOOST_REQUIRE_EQUAL(DetID::string_to_subdetector(""), DetID::Subdetector::kUnknown);
-  BOOST_REQUIRE_EQUAL(DetID::string_to_subdetector("hd_tpc"), DetID::Subdetector::kUnknown);  // case sensitive
+  BOOST_REQUIRE_EQUAL(DetID::string_to_subdetector("hd_tpc"), DetID::Subdetector::kUnknown); // case sensitive
 }
 
 BOOST_AUTO_TEST_CASE(ConversionRoundTrip)
 {
   // Test that conversion to/from string is reversible for all values
   const std::vector<DetID::Subdetector> all_subdetectors = {
-    DetID::Subdetector::kUnknown,
-    DetID::Subdetector::kDAQ,
-    DetID::Subdetector::kHD_PDS,
-    DetID::Subdetector::kHD_TPC,
-    DetID::Subdetector::kHD_CRT,
-    DetID::Subdetector::kVD_CathodePDS,
-    DetID::Subdetector::kVD_MembranePDS,
-    DetID::Subdetector::kVD_BottomTPC,
-    DetID::Subdetector::kVD_TopTPC,
-    DetID::Subdetector::kVD_BernCRT,
-    DetID::Subdetector::kVD_GrenobleCRT,
-    DetID::Subdetector::kNDLAr_TPC,
-    DetID::Subdetector::kNDLAr_PDS,
-    DetID::Subdetector::kND_GAr
+    DetID::Subdetector::kUnknown,        DetID::Subdetector::kDAQ,
+    DetID::Subdetector::kHD_PDS,         DetID::Subdetector::kHD_TPC,
+    DetID::Subdetector::kHD_CRT,         DetID::Subdetector::kVD_CathodePDS,
+    DetID::Subdetector::kVD_MembranePDS, DetID::Subdetector::kVD_BottomTPC,
+    DetID::Subdetector::kVD_TopTPC,      DetID::Subdetector::kVD_BernCRT,
+    DetID::Subdetector::kVD_GrenobleCRT, DetID::Subdetector::kNDLAr_TPC,
+    DetID::Subdetector::kNDLAr_PDS,      DetID::Subdetector::kND_GAr
   };
 
   for (const auto& subdet : all_subdetectors) {
@@ -157,7 +143,7 @@ BOOST_AUTO_TEST_CASE(StreamOperatorRoundTrip)
   std::istringstream iss(ostr.str());
   DetID detid_from_stream;
   iss >> detid_from_stream;
-  
+
   BOOST_REQUIRE_EQUAL(detid_from_stream.subdetector, detid.subdetector);
 }
 
@@ -166,35 +152,28 @@ BOOST_AUTO_TEST_CASE(StreamOperatorRoundTripAll)
   // Test round-trip for all subdetector values:
   // DetID -> (<<) -> string -> (>>) -> DetID', verify equal
   const std::vector<DetID::Subdetector> all_subdetectors = {
-    DetID::Subdetector::kUnknown,
-    DetID::Subdetector::kDAQ,
-    DetID::Subdetector::kHD_PDS,
-    DetID::Subdetector::kHD_TPC,
-    DetID::Subdetector::kHD_CRT,
-    DetID::Subdetector::kVD_CathodePDS,
-    DetID::Subdetector::kVD_MembranePDS,
-    DetID::Subdetector::kVD_BottomTPC,
-    DetID::Subdetector::kVD_TopTPC,
-    DetID::Subdetector::kVD_BernCRT,
-    DetID::Subdetector::kVD_GrenobleCRT,
-    DetID::Subdetector::kNDLAr_TPC,
-    DetID::Subdetector::kNDLAr_PDS,
-    DetID::Subdetector::kND_GAr
+    DetID::Subdetector::kUnknown,        DetID::Subdetector::kDAQ,
+    DetID::Subdetector::kHD_PDS,         DetID::Subdetector::kHD_TPC,
+    DetID::Subdetector::kHD_CRT,         DetID::Subdetector::kVD_CathodePDS,
+    DetID::Subdetector::kVD_MembranePDS, DetID::Subdetector::kVD_BottomTPC,
+    DetID::Subdetector::kVD_TopTPC,      DetID::Subdetector::kVD_BernCRT,
+    DetID::Subdetector::kVD_GrenobleCRT, DetID::Subdetector::kNDLAr_TPC,
+    DetID::Subdetector::kNDLAr_PDS,      DetID::Subdetector::kND_GAr
   };
 
   for (const auto& subdet : all_subdetectors) {
     DetID original(subdet);
-    
+
     // Serialize to string using <<
     std::ostringstream oss;
     oss << original;
     std::string serialized = oss.str();
-    
+
     // Deserialize from string using >>
     std::istringstream iss(serialized);
     DetID recovered;
     iss >> recovered;
-    
+
     // Verify they're equal
     BOOST_REQUIRE_EQUAL(recovered.subdetector, original.subdetector);
   }

--- a/unittest/HSIFrame_test.cxx
+++ b/unittest/HSIFrame_test.cxx
@@ -8,7 +8,7 @@
 
 #include "detdataformats/HSIFrame.hpp"
 
-#define BOOST_TEST_MODULE HSIFrame_test  // NOLINT
+#define BOOST_TEST_MODULE HSIFrame_test // NOLINT
 
 #include "boost/test/unit_test.hpp"
 
@@ -22,25 +22,32 @@ using namespace dunedaq::detdataformats;
 // NOLINTBEGIN(build/unsigned)
 
 namespace {
-  // Helper to create HSIFrame from individual components
-  HSIFrame make_frame(uint32_t version, uint32_t detector_id, uint32_t crate, 
-                      uint32_t slot, uint32_t link,
-                      uint64_t timestamp, uint32_t input_low, uint32_t input_high,
-                      uint32_t trigger, uint32_t sequence)
-  {
-    HSIFrame frame;
-    frame.version = version;
-    frame.detector_id = detector_id;
-    frame.crate = crate;
-    frame.slot = slot;
-    frame.link = link;
-    frame.set_timestamp(timestamp);
-    frame.input_low = input_low;
-    frame.input_high = input_high;
-    frame.trigger = trigger;
-    frame.sequence = sequence;
-    return frame;
-  }
+// Helper to create HSIFrame from individual components
+HSIFrame
+make_frame(uint32_t version,
+           uint32_t detector_id,
+           uint32_t crate,
+           uint32_t slot,
+           uint32_t link,
+           uint64_t timestamp,
+           uint32_t input_low,
+           uint32_t input_high,
+           uint32_t trigger,
+           uint32_t sequence)
+{
+  HSIFrame frame;
+  frame.version = version;
+  frame.detector_id = detector_id;
+  frame.crate = crate;
+  frame.slot = slot;
+  frame.link = link;
+  frame.set_timestamp(timestamp);
+  frame.input_low = input_low;
+  frame.input_high = input_high;
+  frame.trigger = trigger;
+  frame.sequence = sequence;
+  return frame;
+}
 } // namespace ""
 
 BOOST_AUTO_TEST_SUITE(HSIFrame_test)
@@ -48,8 +55,8 @@ BOOST_AUTO_TEST_SUITE(HSIFrame_test)
 BOOST_AUTO_TEST_CASE(DefaultConstruction)
 {
   HSIFrame frame;
-  
-    // Note: bitfield members are uninitialized by default, so we don't test them here
+
+  // Note: bitfield members are uninitialized by default, so we don't test them here
   BOOST_REQUIRE_EQUAL(frame.get_timestamp(), std::numeric_limits<uint64_t>::max());
   BOOST_REQUIRE_EQUAL(frame.input_low, std::numeric_limits<uint32_t>::max());
   BOOST_REQUIRE_EQUAL(frame.input_high, std::numeric_limits<uint32_t>::max());
@@ -60,7 +67,7 @@ BOOST_AUTO_TEST_CASE(DefaultConstruction)
 BOOST_AUTO_TEST_CASE(GetTimestamp)
 {
   HSIFrame frame;
-  
+
   uint64_t ts = frame.get_timestamp();
   BOOST_REQUIRE_EQUAL(ts, std::numeric_limits<uint64_t>::max());
 }
@@ -68,7 +75,7 @@ BOOST_AUTO_TEST_CASE(GetTimestamp)
 BOOST_AUTO_TEST_CASE(SetTimestampMax)
 {
   HSIFrame frame;
-  
+
   uint64_t max_ts = std::numeric_limits<uint64_t>::max();
   frame.set_timestamp(max_ts);
   BOOST_REQUIRE_EQUAL(frame.get_timestamp(), max_ts);
@@ -79,28 +86,26 @@ BOOST_AUTO_TEST_CASE(SetTimestampMax)
 BOOST_AUTO_TEST_CASE(SetTimestampSplit)
 {
   HSIFrame frame;
-  
+
   // Test a 64-bit value that crosses the 32-bit boundary
   uint64_t ts = 0x0123456789ABCDEF;
   frame.set_timestamp(ts);
-  
+
   BOOST_REQUIRE_EQUAL(frame.get_timestamp(), ts);
-  BOOST_REQUIRE_EQUAL(frame.timestamp_low, 0x89ABCDEF);      // lower 32 bits
-  BOOST_REQUIRE_EQUAL(frame.timestamp_high, 0x01234567);     // upper 32 bits
+  BOOST_REQUIRE_EQUAL(frame.timestamp_low, 0x89ABCDEF);  // lower 32 bits
+  BOOST_REQUIRE_EQUAL(frame.timestamp_high, 0x01234567); // upper 32 bits
 }
 
 BOOST_AUTO_TEST_CASE(TimestampRoundTrip)
 {
   // Test a range of timestamp values
-  const std::vector<uint64_t> test_timestamps = {
-    0,
-    1,
-    0xFF,
-    0xFFFFFFFF,  // max 32-bit
-    0x100000000,  // just above 32-bit
-    0x123456789ABCDEF0,
-    std::numeric_limits<uint64_t>::max()
-  };
+  const std::vector<uint64_t> test_timestamps = { 0,
+                                                  1,
+                                                  0xFF,
+                                                  0xFFFFFFFF,  // max 32-bit
+                                                  0x100000000, // just above 32-bit
+                                                  0x123456789ABCDEF0,
+                                                  std::numeric_limits<uint64_t>::max() };
 
   for (const auto& ts : test_timestamps) {
     HSIFrame frame;
@@ -112,13 +117,13 @@ BOOST_AUTO_TEST_CASE(TimestampRoundTrip)
 BOOST_AUTO_TEST_CASE(BitfieldMembers)
 {
   HSIFrame frame;
-  
+
   frame.version = 5;
   frame.detector_id = 3;
   frame.crate = 7;
   frame.slot = 2;
   frame.link = 42;
-  
+
   BOOST_REQUIRE_EQUAL(frame.version, 5);
   BOOST_REQUIRE_EQUAL(frame.detector_id, 3);
   BOOST_REQUIRE_EQUAL(frame.crate, 7);
@@ -129,23 +134,23 @@ BOOST_AUTO_TEST_CASE(BitfieldMembers)
 BOOST_AUTO_TEST_CASE(BitfieldMask)
 {
   HSIFrame frame;
-  
+
   // version is 6 bits: max value 63
   frame.version = 63;
   BOOST_REQUIRE_EQUAL(frame.version, 63);
-  
+
   // detector_id is 6 bits: max value 63
   frame.detector_id = 63;
   BOOST_REQUIRE_EQUAL(frame.detector_id, 63);
-  
+
   // crate is 10 bits: max value 1023
   frame.crate = 1023;
   BOOST_REQUIRE_EQUAL(frame.crate, 1023);
-  
+
   // slot is 4 bits: max value 15
   frame.slot = 15;
   BOOST_REQUIRE_EQUAL(frame.slot, 15);
-  
+
   // link is 6 bits: max value 63
   frame.link = 63;
   BOOST_REQUIRE_EQUAL(frame.link, 63);
@@ -154,12 +159,12 @@ BOOST_AUTO_TEST_CASE(BitfieldMask)
 BOOST_AUTO_TEST_CASE(RegularMembers)
 {
   HSIFrame frame;
-  
+
   frame.input_low = 0x11223344;
   frame.input_high = 0x55667788;
   frame.trigger = 0xDEADBEEF;
   frame.sequence = 0xCAFEBABE;
-  
+
   BOOST_REQUIRE_EQUAL(frame.input_low, 0x11223344);
   BOOST_REQUIRE_EQUAL(frame.input_high, 0x55667788);
   BOOST_REQUIRE_EQUAL(frame.trigger, 0xDEADBEEF);
@@ -168,19 +173,18 @@ BOOST_AUTO_TEST_CASE(RegularMembers)
 
 BOOST_AUTO_TEST_CASE(CompleteFrameSetup)
 {
-  HSIFrame frame = make_frame(
-    5,                    // version
-    3,                    // detector_id
-    7,                    // crate
-    2,                    // slot
-    42,                   // link
-    0x0123456789ABCDEF,   // timestamp
-    0x11111111,           // input_low
-    0x22222222,           // input_high
-    0x33333333,           // trigger
-    0x44444444            // sequence
+  HSIFrame frame = make_frame(5,                  // version
+                              3,                  // detector_id
+                              7,                  // crate
+                              2,                  // slot
+                              42,                 // link
+                              0x0123456789ABCDEF, // timestamp
+                              0x11111111,         // input_low
+                              0x22222222,         // input_high
+                              0x33333333,         // trigger
+                              0x44444444          // sequence
   );
-  
+
   BOOST_REQUIRE_EQUAL(frame.version, 5);
   BOOST_REQUIRE_EQUAL(frame.detector_id, 3);
   BOOST_REQUIRE_EQUAL(frame.crate, 7);
@@ -196,21 +200,16 @@ BOOST_AUTO_TEST_CASE(CompleteFrameSetup)
 BOOST_AUTO_TEST_CASE(ByteRoundTrip)
 {
   // Create a frame with specific values
-  HSIFrame original = make_frame(
-    5, 3, 7, 2, 42,
-    0x0123456789ABCDEF,
-    0x11111111, 0x22222222,
-    0x33333333, 0x44444444
-  );
-  
+  HSIFrame original = make_frame(5, 3, 7, 2, 42, 0x0123456789ABCDEF, 0x11111111, 0x22222222, 0x33333333, 0x44444444);
+
   // Serialize to bytes
-  uint8_t buffer[ sizeof(HSIFrame) ]; // NOLINT(modernize-avoid-c-arrays)
+  uint8_t buffer[sizeof(HSIFrame)]; // NOLINT(modernize-avoid-c-arrays)
   std::memcpy(buffer, &original, sizeof(HSIFrame));
 
   // Deserialize from bytes
   HSIFrame recovered;
   std::memcpy(&recovered, buffer, sizeof(HSIFrame));
-  
+
   // Verify all fields match
   BOOST_REQUIRE_EQUAL(recovered.version, original.version);
   BOOST_REQUIRE_EQUAL(recovered.detector_id, original.detector_id);
@@ -227,15 +226,15 @@ BOOST_AUTO_TEST_CASE(ByteRoundTrip)
 BOOST_AUTO_TEST_CASE(TimestampEndianness)
 {
   HSIFrame frame;
-  
+
   // Set timestamp to a value where endianness matters
   uint64_t ts = 0x0102030405060708;
   frame.set_timestamp(ts);
-  
+
   // On little-endian: low 32 bits should be 0x05060708, high 32 bits should be 0x01020304
   BOOST_REQUIRE_EQUAL(frame.timestamp_low, 0x05060708);
   BOOST_REQUIRE_EQUAL(frame.timestamp_high, 0x01020304);
-  
+
   // Verify get_timestamp reconstructs it correctly
   BOOST_REQUIRE_EQUAL(frame.get_timestamp(), ts);
 }
@@ -244,32 +243,32 @@ BOOST_AUTO_TEST_CASE(MultipleFramesIndependent)
 {
   HSIFrame frame1 = make_frame(1, 1, 1, 1, 1, 0x1111111111111111, 0x11, 0x11, 0x11, 0x11);
   HSIFrame frame2 = make_frame(2, 2, 2, 2, 2, 0x2222222222222222, 0x22, 0x22, 0x22, 0x22);
-  
+
   // Verify they're independent
   BOOST_REQUIRE_EQUAL(frame1.version, 1);
   BOOST_REQUIRE_EQUAL(frame2.version, 2);
-  
+
   BOOST_REQUIRE_EQUAL(frame1.get_timestamp(), 0x1111111111111111);
   BOOST_REQUIRE_EQUAL(frame2.get_timestamp(), 0x2222222222222222);
-  
+
   // Modify frame1, verify frame2 unchanged
-    frame1.version = 5;  // Use a value that fits in 6 bits
-      BOOST_REQUIRE_EQUAL(frame1.version, 5);
-    BOOST_REQUIRE_EQUAL(frame1.version, 5);
+  frame1.version = 5; // Use a value that fits in 6 bits
+  BOOST_REQUIRE_EQUAL(frame1.version, 5);
+  BOOST_REQUIRE_EQUAL(frame1.version, 5);
   BOOST_REQUIRE_EQUAL(frame2.version, 2);
 }
 
 BOOST_AUTO_TEST_CASE(EdgeCaseHighBitfieldValues)
 {
   HSIFrame frame;
-  
+
   // Set all bitfields to maximum valid values for their bit widths
-  frame.version = (1u << 6) - 1;         // 6 bits: 0x3F = 63
-  frame.detector_id = (1u << 6) - 1;     // 6 bits: 0x3F = 63
-  frame.crate = (1u << 10) - 1;          // 10 bits: 0x3FF = 1023
-  frame.slot = (1u << 4) - 1;            // 4 bits: 0xF = 15
-  frame.link = (1u << 6) - 1;            // 6 bits: 0x3F = 63
-  
+  frame.version = (1u << 6) - 1;     // 6 bits: 0x3F = 63
+  frame.detector_id = (1u << 6) - 1; // 6 bits: 0x3F = 63
+  frame.crate = (1u << 10) - 1;      // 10 bits: 0x3FF = 1023
+  frame.slot = (1u << 4) - 1;        // 4 bits: 0xF = 15
+  frame.link = (1u << 6) - 1;        // 6 bits: 0x3F = 63
+
   // Verify all are at max
   BOOST_REQUIRE_EQUAL(frame.version, 63);
   BOOST_REQUIRE_EQUAL(frame.detector_id, 63);


### PR DESCRIPTION
# Description

This is a followup to the refactoring performed in PR #101; both this and that PR are part of addressing Issue #100. It's simply the effect of running `dbt-clang-format.sh` over the code + one line where I needed to add `// NOLINT(build/unsigned)` because of a line break the script introduced. 

Eye test should be sufficient. 


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [x] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

I did skip integration testing as this is a `dbt-clang-format.sh` whitespace modification right on the heels of the fully-tested PR #101. 

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

